### PR TITLE
ADBDEV-1714 Avoid lock acquisition for foreign tables

### DIFF
--- a/backup/data_test.go
+++ b/backup/data_test.go
@@ -173,24 +173,6 @@ var _ = Describe("backup/data tests", func() {
 			Expect(rowsCopiedMap[0]).To(Equal(int64(10)))
 			Expect(counters.NumRegTables).To(Equal(int64(1)))
 		})
-		It("backs up a single external table", func() {
-			_ = cmdFlags.Set(options.LEAF_PARTITION_DATA, "false")
-			testTable.IsExternal = true
-			err := backup.BackupSingleTableData(testTable, rowsCopiedMap, &counters, 0)
-
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(rowsCopiedMap).To(BeEmpty())
-			Expect(counters.NumRegTables).To(Equal(int64(0)))
-		})
-		It("backs up a single foreign table", func() {
-			_ = cmdFlags.Set(options.LEAF_PARTITION_DATA, "false")
-			testTable.ForeignDef = backup.ForeignTableDefinition{Oid: 23, Options: "", Server: "fs"}
-			err := backup.BackupSingleTableData(testTable, rowsCopiedMap, &counters, 0)
-
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(rowsCopiedMap).To(BeEmpty())
-			Expect(counters.NumRegTables).To(Equal(int64(0)))
-		})
 	})
 	Describe("CheckDBContainsData", func() {
 		config := history.BackupConfig{}

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1356,6 +1356,33 @@ var _ = Describe("backup and restore end to end tests", func() {
 
 		Expect(stdout).To(ContainSubstring("Backup completed successfully"))
 	})
+	It("successfully backs up foreign tables", func() {
+		if backupConn.Version.Before("6") {
+			Skip("Test does not apply for GPDB versions before 6")
+		}
+		testhelper.AssertQueryRuns(backupConn,
+			"CREATE FOREIGN DATA WRAPPER foreigndatawrapper;")
+		defer testhelper.AssertQueryRuns(backupConn,
+			"DROP FOREIGN DATA WRAPPER foreigndatawrapper CASCADE;")
+		testhelper.AssertQueryRuns(backupConn,
+			"CREATE SERVER sc FOREIGN DATA WRAPPER foreigndatawrapper;")
+		testhelper.AssertQueryRuns(backupConn,
+			"CREATE FOREIGN TABLE public.ft1 (field1 text) SERVER sc")
+		testhelper.AssertQueryRuns(backupConn,
+			"CREATE FOREIGN TABLE public.ft2 (field1 text) SERVER sc")
+		args := []string{
+			"--dbname", "testdb",
+			"--backup-dir", backupDir,
+			"--jobs", "4",
+			"--verbose"}
+		cmd := exec.Command(gpbackupPath, args...)
+		output, _ := cmd.CombinedOutput()
+		stdout := string(output)
+		Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+		Expect(stdout).To(ContainSubstring("Skipping data backup of table public.ft1"))
+		Expect(stdout).To(ContainSubstring("Skipping data backup of table public.ft2"))
+		Expect(stdout).To(ContainSubstring("Skipped data backup of 2 external/foreign table(s)"))
+	})
 	It("runs gpbackup with --version flag", func() {
 		if useOldBackupVersion {
 			Skip("This test is not needed for old backup versions")


### PR DESCRIPTION
backupDataForAllTables function used to attempt to acquire AccessShareLock on foreign tables. This behavior is fixed by
skipping lock acquisition not only for main worker thread (worker 0) but also for the tables, that don't require data
backup (there is no need to acquire locks on external tables in non-main threads as well).

Gpbackup flow implies, that before starting backup of tables' data, it performs their metadata backup. For this, at the very beginning gpbackup acquires AccessShareLock for all the regular tables (relkind='r'), that are going to be backed up. Only after that  list of tables for which metadata should be backed up is extended with foreign tables.

However when gpbackup starts to backup data of the tables, the list still contains foreign tables. backupDataForAllTables function creates pool of goroutines each of which tries to, again, acquire AccessShareLock and start COPY command. Here comes the error on LOCK TABLE command.