### PR TITLE
ADBDEV-1886. Implement ZSTD compression support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/greenplum-db/gp-common-go-libs v1.0.5-0.20201005232358-ee3f0135881b
 	github.com/jackc/pgconn v1.7.0
+	github.com/klauspost/compress v1.13.1
 	github.com/lib/pq v1.3.0
 	github.com/mattn/go-runewidth v0.0.8 // indirect
 	github.com/nightlyone/lockfile v0.0.0-20200124072040-edb130adc195

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
+github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
@@ -108,6 +110,8 @@ github.com/jackc/puddle v1.1.2/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dv
 github.com/jmoiron/sqlx v0.0.0-20180614180643-0dae4fefe7c0 h1:5B0uxl2lzNRVkJVg+uGHxWtRt4C0Wjc6kJKo5XYx8xE=
 github.com/jmoiron/sqlx v0.0.0-20180614180643-0dae4fefe7c0/go.mod h1:IiEW3SEiiErVyFdH8NTuWjSifiEQKUoyK3LNqr2kCHU=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.13.1 h1:wXr2uRxZTJXHLly6qhJabee5JqIhTRoLBhDOA74hDEQ=
+github.com/klauspost/compress v1.13.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/helper/backup_helper.go
+++ b/helper/backup_helper.go
@@ -137,6 +137,10 @@ func getBackupPipeWriter() (pipe BackupPipeWriterCloser, writeCmd *exec.Cmd, err
 		pipe, err = NewGZipBackupPipeWriterCloser(writeHandle, *compressionLevel)
 		return
 	}
+	if *compressionType == "zstd" {
+		pipe, err = NewZSTDBackupPipeWriterCloser(writeHandle, *compressionLevel)
+		return
+	}
 
 	writeHandle.Close()
 	return nil, nil, fmt.Errorf("unknown compression type '%s' (compression level %d)", *compressionType, *compressionLevel)

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -101,7 +101,7 @@ func InitializeGlobals() {
 	backupAgent = flag.Bool("backup-agent", false, "Use gpbackup_helper as an agent for backup")
 	content = flag.Int("content", -2, "Content ID of the corresponding segment")
 	compressionLevel = flag.Int("compression-level", 0, "The level of compression. O indicates no compression.")
-	compressionType = flag.String("compression-type", "gzip", "The type of compression. Valid values are 'gzip'")
+	compressionType = flag.String("compression-type", "gzip", "The type of compression. Valid values are 'gzip', 'zstd'")
 	dataFile = flag.String("data-file", "", "Absolute path to the data file")
 	oidFile = flag.String("oid-file", "", "Absolute path to the file containing a list of oids to restore")
 	onErrorContinue = flag.Bool("on-error-continue", false, "Continue restore even when encountering an error")

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -100,7 +100,7 @@ func InitializeGlobals() {
 
 	backupAgent = flag.Bool("backup-agent", false, "Use gpbackup_helper as an agent for backup")
 	content = flag.Int("content", -2, "Content ID of the corresponding segment")
-	compressionLevel = flag.Int("compression-level", 0, "The level of compression. O indicates no compression.")
+	compressionLevel = flag.Int("compression-level", 0, "The level of compression. O indicates no compression. Range of valid values depends on compression type")
 	compressionType = flag.String("compression-type", "gzip", "The type of compression. Valid values are 'gzip', 'zstd'")
 	dataFile = flag.String("data-file", "", "Absolute path to the data file")
 	oidFile = flag.String("oid-file", "", "Absolute path to the file containing a list of oids to restore")

--- a/helper/restore_helper.go
+++ b/helper/restore_helper.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/greenplum-db/gpbackup/toc"
 	"github.com/greenplum-db/gpbackup/utils"
+	"github.com/klauspost/compress/zstd"
 	"github.com/pkg/errors"
 )
 
@@ -19,10 +20,11 @@ import (
  * Restore specific functions
  */
 type ReaderType string
+
 const (
-	SEEKABLE ReaderType = "seekable"	// reader which supports seek
-	NONSEEKABLE			= "discard"		// reader which is not seekable
-	SUBSET				= "subset"		// reader which operates on pre filtered data
+	SEEKABLE    ReaderType = "seekable" // reader which supports seek
+	NONSEEKABLE            = "discard"  // reader which is not seekable
+	SUBSET                 = "subset"   // reader which operates on pre filtered data
 )
 
 /* RestoreReader structure to wrap the underlying reader.
@@ -134,7 +136,7 @@ func doRestoreAgent() error {
 		}
 
 		log(fmt.Sprintf("Restoring table with oid %d", oid))
-		bytesRead, err = reader.copyData(int64(end-start))
+		bytesRead, err = reader.copyData(int64(end - start))
 		if err != nil {
 			// In case COPY FROM or copyN fails in the middle of a load. We
 			// need to update the lastByte with the amount of bytes that was
@@ -215,6 +217,12 @@ func getRestoreDataReader(toc *toc.SegmentTOC, oidList []int) (*RestoreReader, e
 			return nil, err
 		}
 		restoreReader.bufReader = bufio.NewReader(gzipReader)
+	} else if strings.HasSuffix(*dataFile, ".zst") {
+		zstdReader, err := zstd.NewReader(readHandle)
+		if err != nil {
+			return nil, err
+		}
+		restoreReader.bufReader = bufio.NewReader(zstdReader)
 	} else {
 		restoreReader.bufReader = bufio.NewReader(readHandle)
 	}
@@ -241,7 +249,7 @@ func getRestorePipeWriter(currentPipe string) (*bufio.Writer, *os.File, error) {
 	// adopting the new kernel, we must only use the bare essential methods Write() and
 	// Close() for the pipe to avoid an extra buffer read that can happen in error
 	// scenarios with --on-error-continue.
-	pipeWriter := bufio.NewWriter(struct{io.WriteCloser}{fileHandle})
+	pipeWriter := bufio.NewWriter(struct{ io.WriteCloser }{fileHandle})
 
 	return pipeWriter, fileHandle, nil
 }

--- a/helper/restore_helper.go
+++ b/helper/restore_helper.go
@@ -194,7 +194,7 @@ func getRestoreDataReader(toc *toc.SegmentTOC, oidList []int) (*RestoreReader, e
 			restoreReader.readerType = NONSEEKABLE
 		}
 	} else {
-		if *isFiltered && !strings.HasSuffix(*dataFile, ".gz") {
+		if *isFiltered && !strings.HasSuffix(*dataFile, ".gz") && !strings.HasSuffix(*dataFile, ".zst") {
 			// Seekable reader if backup is not compressed and filters are set
 			seekHandle, err = os.Open(*dataFile)
 			restoreReader.readerType = SEEKABLE
@@ -261,7 +261,7 @@ func startRestorePluginCommand(toc *toc.SegmentTOC, oidList []int) (io.Reader, b
 		return nil, false, err
 	}
 	cmdStr := ""
-	if pluginConfig.CanRestoreSubset() && *isFiltered && !strings.HasSuffix(*dataFile, ".gz") {
+	if pluginConfig.CanRestoreSubset() && *isFiltered && !strings.HasSuffix(*dataFile, ".gz") && !strings.HasSuffix(*dataFile, ".zst") {
 		offsetsFile, _ := ioutil.TempFile("/tmp", "gprestore_offsets_")
 		defer func() {
 			offsetsFile.Close()

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"bufio"
 	"bytes"
 	"compress/gzip"
 	"fmt"
@@ -323,16 +322,14 @@ func setupRestoreFiles(compressionType string, withPlugin bool) {
 
 	if compressionType == "gzip" {
 		f, _ := os.Create(dataFile + ".gz")
+		defer f.Close()
 		gzipf := gzip.NewWriter(f)
-		defer func() {
-			_ = gzipf.Close()
-		}()
+		defer gzipf.Close()
 		_, _ = gzipf.Write([]byte(expectedData))
 	} else if compressionType == "zstd" {
 		f, _ := os.Create(dataFile + ".zst")
 		defer f.Close()
-		bufiof := bufio.NewWriter(f)
-		zstdf, _ := zstd.NewWriter(bufiof)
+		zstdf, _ := zstd.NewWriter(f)
 		defer zstdf.Close()
 		_, _ = zstdf.Write([]byte(expectedData))
 	} else {

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	"github.com/greenplum-db/gp-common-go-libs/operating"
+	"github.com/klauspost/compress/zstd"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -98,7 +100,7 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			err := helperCmd.Wait()
 			printHelperLogOnError(err)
 			Expect(err).ToNot(HaveOccurred())
-			assertBackupArtifacts(false, false)
+			assertBackupArtifacts(false)
 		})
 		It("runs backup gpbackup_helper with data exceeding pipe buffer size", func() {
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-level", "0", "--data-file", dataFileFullPath)
@@ -107,13 +109,21 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			printHelperLogOnError(err)
 			Expect(err).ToNot(HaveOccurred())
 		})
-		It("runs backup gpbackup_helper with compression", func() {
+		It("runs backup gpbackup_helper with gzip compression", func() {
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-type", "gzip", "--compression-level", "1", "--data-file", dataFileFullPath+".gz")
 			writeToPipes(defaultData)
 			err := helperCmd.Wait()
 			printHelperLogOnError(err)
 			Expect(err).ToNot(HaveOccurred())
-			assertBackupArtifacts(true, false)
+			assertBackupArtifactsWithCompression("gzip", false)
+		})
+		It("runs backup gpbackup_helper with zstd compression", func() {
+			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-type", "zstd", "--compression-level", "1", "--data-file", dataFileFullPath+".zst")
+			writeToPipes(defaultData)
+			err := helperCmd.Wait()
+			printHelperLogOnError(err)
+			Expect(err).ToNot(HaveOccurred())
+			assertBackupArtifactsWithCompression("zstd", false)
 		})
 		It("runs backup gpbackup_helper without compression with plugin", func() {
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-level", "0", "--data-file", dataFileFullPath, "--plugin-config", pluginConfigPath)
@@ -121,15 +131,23 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			err := helperCmd.Wait()
 			printHelperLogOnError(err)
 			Expect(err).ToNot(HaveOccurred())
-			assertBackupArtifacts(false, true)
+			assertBackupArtifacts(true)
 		})
-		It("runs backup gpbackup_helper with compression with plugin", func() {
+		It("runs backup gpbackup_helper with gzip compression with plugin", func() {
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-type", "gzip", "--compression-level", "1", "--data-file", dataFileFullPath+".gz", "--plugin-config", pluginConfigPath)
 			writeToPipes(defaultData)
 			err := helperCmd.Wait()
 			printHelperLogOnError(err)
 			Expect(err).ToNot(HaveOccurred())
-			assertBackupArtifacts(true, true)
+			assertBackupArtifactsWithCompression("gzip", true)
+		})
+		It("runs backup gpbackup_helper with zstd compression with plugin", func() {
+			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-type", "zstd", "--compression-level", "1", "--data-file", dataFileFullPath+".zst", "--plugin-config", pluginConfigPath)
+			writeToPipes(defaultData)
+			err := helperCmd.Wait()
+			printHelperLogOnError(err)
+			Expect(err).ToNot(HaveOccurred())
+			assertBackupArtifactsWithCompression("zstd", true)
 		})
 		It("Generates error file when backup agent interrupted", func() {
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-level", "0", "--data-file", dataFileFullPath)
@@ -143,7 +161,7 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 	})
 	Context("restore tests", func() {
 		It("runs restore gpbackup_helper without compression", func() {
-			setupRestoreFiles(false, false)
+			setupRestoreFiles("", false)
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--restore-agent", "--data-file", dataFileFullPath)
 			for _, i := range []int{1, 3} {
 				contents, _ := ioutil.ReadFile(fmt.Sprintf("%s_%d", pipeFile, i))
@@ -154,8 +172,8 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			assertNoErrors()
 		})
-		It("runs restore gpbackup_helper with compression", func() {
-			setupRestoreFiles(true, false)
+		It("runs restore gpbackup_helper with gzip compression", func() {
+			setupRestoreFiles("gzip", false)
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--restore-agent", "--data-file", dataFileFullPath+".gz")
 			for _, i := range []int{1, 3} {
 				contents, _ := ioutil.ReadFile(fmt.Sprintf("%s_%d", pipeFile, i))
@@ -166,8 +184,20 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			assertNoErrors()
 		})
+		It("runs restore gpbackup_helper with zstd compression", func() {
+			setupRestoreFiles("zstd", false)
+			helperCmd := gpbackupHelper(gpbackupHelperPath, "--restore-agent", "--data-file", dataFileFullPath+".zst")
+			for _, i := range []int{1, 3} {
+				contents, _ := ioutil.ReadFile(fmt.Sprintf("%s_%d", pipeFile, i))
+				Expect(string(contents)).To(Equal("here is some data\n"))
+			}
+			err := helperCmd.Wait()
+			printHelperLogOnError(err)
+			Expect(err).ToNot(HaveOccurred())
+			assertNoErrors()
+		})
 		It("runs restore gpbackup_helper without compression with plugin", func() {
-			setupRestoreFiles(false, true)
+			setupRestoreFiles("", true)
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--restore-agent", "--data-file", dataFileFullPath, "--plugin-config", pluginConfigPath)
 			for _, i := range []int{1, 3} {
 				contents, _ := ioutil.ReadFile(fmt.Sprintf("%s_%d", pipeFile, i))
@@ -178,8 +208,8 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			assertNoErrors()
 		})
-		It("runs restore gpbackup_helper with compression with plugin", func() {
-			setupRestoreFiles(true, true)
+		It("runs restore gpbackup_helper with gzip compression with plugin", func() {
+			setupRestoreFiles("gzip", true)
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--restore-agent", "--data-file", dataFileFullPath+".gz", "--plugin-config", pluginConfigPath)
 			for _, i := range []int{1, 3} {
 				contents, _ := ioutil.ReadFile(fmt.Sprintf("%s_%d", pipeFile, i))
@@ -190,8 +220,20 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			assertNoErrors()
 		})
+		It("runs restore gpbackup_helper with zstd compression with plugin", func() {
+			setupRestoreFiles("zstd", true)
+			helperCmd := gpbackupHelper(gpbackupHelperPath, "--restore-agent", "--data-file", dataFileFullPath+".zst", "--plugin-config", pluginConfigPath)
+			for _, i := range []int{1, 3} {
+				contents, _ := ioutil.ReadFile(fmt.Sprintf("%s_%d", pipeFile, i))
+				Expect(string(contents)).To(Equal("here is some data\n"))
+			}
+			err := helperCmd.Wait()
+			printHelperLogOnError(err)
+			Expect(err).ToNot(HaveOccurred())
+			assertNoErrors()
+		})
 		It("Generates error file when restore agent interrupted", func() {
-			setupRestoreFiles(true, false)
+			setupRestoreFiles("gzip", false)
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--restore-agent", "--data-file", dataFileFullPath+".gz")
 			waitForPipeCreation()
 			err := helperCmd.Process.Signal(os.Interrupt)
@@ -270,20 +312,29 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 	})
 })
 
-func setupRestoreFiles(withCompression bool, withPlugin bool) {
+func setupRestoreFiles(compressionType string, withPlugin bool) {
 	dataFile := dataFileFullPath
 	if withPlugin {
 		dataFile = pluginBackupPath
 	}
+
 	f, _ := os.Create(oidFile)
 	_, _ = f.WriteString("1\n3\n")
-	if withCompression {
+
+	if compressionType == "gzip" {
 		f, _ := os.Create(dataFile + ".gz")
 		gzipf := gzip.NewWriter(f)
 		defer func() {
 			_ = gzipf.Close()
 		}()
 		_, _ = gzipf.Write([]byte(expectedData))
+	} else if compressionType == "zstd" {
+		f, _ := os.Create(dataFile + ".zst")
+		defer f.Close()
+		bufiof := bufio.NewWriter(f)
+		zstdf, _ := zstd.NewWriter(bufiof)
+		defer zstdf.Close()
+		_, _ = zstdf.Write([]byte(expectedData))
 	} else {
 		f, _ := os.Create(dataFile)
 		_, _ = f.WriteString(expectedData)
@@ -306,28 +357,58 @@ func assertErrorsHandled() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(pipes).To(BeEmpty())
 }
-func assertBackupArtifacts(withCompression bool, withPlugin bool) {
+
+func assertBackupArtifacts(withPlugin bool) {
 	var contents []byte
 	var err error
 	dataFile := dataFileFullPath
 	if withPlugin {
 		dataFile = pluginBackupPath
 	}
-	if withCompression {
-		contents, err = ioutil.ReadFile(dataFile + ".gz")
-		Expect(err).ToNot(HaveOccurred())
-		r, _ := gzip.NewReader(bytes.NewReader(contents))
-		contents, _ = ioutil.ReadAll(r)
-
-	} else {
-		contents, err = ioutil.ReadFile(dataFile)
-		Expect(err).ToNot(HaveOccurred())
-	}
+	contents, err = ioutil.ReadFile(dataFile)
+	Expect(err).ToNot(HaveOccurred())
 	Expect(string(contents)).To(Equal(expectedData))
 
 	contents, err = ioutil.ReadFile(tocFile)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(string(contents)).To(Equal(expectedTOC))
+	assertNoErrors()
+}
+
+func assertBackupArtifactsWithCompression(compressionType string, withPlugin bool) {
+	var contents []byte
+	var err error
+
+	dataFile := dataFileFullPath
+	if withPlugin {
+		dataFile = pluginBackupPath
+	}
+
+	if compressionType == "gzip" {
+		contents, err = ioutil.ReadFile(dataFile + ".gz")
+	} else if compressionType == "zstd" {
+		contents, err = ioutil.ReadFile(dataFile + ".zst")
+	} else {
+		Fail("unknown compression type " + compressionType)
+	}
+	Expect(err).ToNot(HaveOccurred())
+
+	if compressionType == "gzip" {
+		r, _ := gzip.NewReader(bytes.NewReader(contents))
+		contents, _ = ioutil.ReadAll(r)
+		Expect(string(contents)).To(Equal(expectedData))
+	} else if compressionType == "zstd" {
+		r, _ := zstd.NewReader(bytes.NewReader(contents))
+		contents, _ = ioutil.ReadAll(r)
+		Expect(string(contents)).To(Equal(expectedData))
+	} else {
+		Fail("unknown compression type " + compressionType)
+	}
+
+	contents, err = ioutil.ReadFile(tocFile)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(string(contents)).To(Equal(expectedTOC))
+
 	assertNoErrors()
 }
 

--- a/options/flag.go
+++ b/options/flag.go
@@ -52,7 +52,7 @@ const (
 
 func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.String(BACKUP_DIR, "", "The absolute path of the directory to which all backup files will be written")
-	flagSet.String(COMPRESSION_TYPE, "gzip", "Type of compression to use during data backup. Valid values are: 'gzip'")
+	flagSet.String(COMPRESSION_TYPE, "gzip", "Type of compression to use during data backup. Valid values are: 'gzip', 'zstd'")
 	flagSet.Int(COMPRESSION_LEVEL, 1, "Level of compression to use during data backup. Valid values are between 1 and 9.")
 	flagSet.Bool(DATA_ONLY, false, "Only back up data, do not back up metadata")
 	flagSet.String(DBNAME, "", "The database to be backed up")

--- a/options/flag.go
+++ b/options/flag.go
@@ -52,8 +52,8 @@ const (
 
 func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.String(BACKUP_DIR, "", "The absolute path of the directory to which all backup files will be written")
-	flagSet.String(COMPRESSION_TYPE, "gzip", "Type of compression to use during data backup. Valid values are: 'gzip', 'zstd'")
-	flagSet.Int(COMPRESSION_LEVEL, 1, "Level of compression to use during data backup. Valid values are between 1 and 9.")
+	flagSet.String(COMPRESSION_TYPE, "gzip", "Type of compression to use during data backup. Valid values are 'gzip', 'zstd'")
+	flagSet.Int(COMPRESSION_LEVEL, 1, "Level of compression to use during data backup. Range of valid values depends on compression type")
 	flagSet.Bool(DATA_ONLY, false, "Only back up data, do not back up metadata")
 	flagSet.String(DBNAME, "", "The database to be backed up")
 	flagSet.Bool(DEBUG, false, "Print verbose and debug log messages")

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -21,11 +21,20 @@ var _ = Describe("restore/data tests", func() {
 			backup.SetPluginConfig(nil)
 			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "")
 		})
-		It("will restore a table from its own file with compression", func() {
+		It("will restore a table from its own file with gzip compression", func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "gzip", OutputCommand: "gzip -c -1", InputCommand: "gzip -d -c", Extension: ".gz"})
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz | gzip -d -c' WITH CSV DELIMITER ',' ON SEGMENT;")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz"
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from its own file with zstd compression", func() {
+			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "zstd", OutputCommand: "zstd --compress -1 -c", InputCommand: "zstd --decompress -c", Extension: ".zst"})
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst | zstd --decompress -c' WITH CSV DELIMITER ',' ON SEGMENT;")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst"
 			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
 
 			Expect(err).ShouldNot(HaveOccurred())
@@ -46,7 +55,7 @@ var _ = Describe("restore/data tests", func() {
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
-		It("will restore a table from its own file with compression using a plugin", func() {
+		It("will restore a table from its own file with gzip compression using a plugin", func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "gzip", OutputCommand: "gzip -c -1", InputCommand: "gzip -d -c", Extension: ".gz"})
 			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "/tmp/plugin_config")
 			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
@@ -55,6 +64,19 @@ var _ = Describe("restore/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from its own file with zstd compression using a plugin", func() {
+			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "zstd", OutputCommand: "zstd --compress -1 -c", InputCommand: "zstd --decompress -c", Extension: ".zst"})
+			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "/tmp/plugin_config")
+			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
+			restore.SetPluginConfig(&pluginConfig)
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM '/tmp/fake-plugin.sh restore_data /tmp/plugin_config <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst | zstd --decompress -c' WITH CSV DELIMITER ',' ON SEGMENT;")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst"
 			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
 
 			Expect(err).ShouldNot(HaveOccurred())

--- a/utils/compression.go
+++ b/utils/compression.go
@@ -23,6 +23,11 @@ func InitializePipeThroughParameters(compress bool, compressionType string, comp
 		pipeThroughProgram = PipeThroughProgram{Name: "gzip", OutputCommand: fmt.Sprintf("gzip -c -%d", compressionLevel), InputCommand: "gzip -d -c", Extension: ".gz"}
 		return
 	}
+
+	if compressionType == "zstd" {
+		pipeThroughProgram = PipeThroughProgram{Name: "zstd", OutputCommand: fmt.Sprintf("zstd --compress -%d -c", compressionLevel), InputCommand: "zstd --decompress -c", Extension: ".zst"}
+		return
+	}
 }
 
 func GetPipeThroughProgram() PipeThroughProgram {

--- a/utils/compression_test.go
+++ b/utils/compression_test.go
@@ -43,7 +43,7 @@ var _ = Describe("utils/compression tests", func() {
 			resultProgram := utils.GetPipeThroughProgram()
 			structmatcher.ExpectStructsToMatch(&expectedProgram, &resultProgram)
 		})
-		It("initializes to use gzip when passed compression and a level", func() {
+		It("initializes to use gzip when passed compression type gzip and a level", func() {
 			originalProgram := utils.GetPipeThroughProgram()
 			defer utils.SetPipeThroughProgram(originalProgram)
 			expectedProgram := utils.PipeThroughProgram{
@@ -53,6 +53,19 @@ var _ = Describe("utils/compression tests", func() {
 				Extension:     ".gz",
 			}
 			utils.InitializePipeThroughParameters(true, "gzip", 7)
+			resultProgram := utils.GetPipeThroughProgram()
+			structmatcher.ExpectStructsToMatch(&expectedProgram, &resultProgram)
+		})
+		It("initializes to use zstd when passed compression type zstd and a level", func() {
+			originalProgram := utils.GetPipeThroughProgram()
+			defer utils.SetPipeThroughProgram(originalProgram)
+			expectedProgram := utils.PipeThroughProgram{
+				Name:          "zstd",
+				OutputCommand: "zstd --compress -7 -c",
+				InputCommand:  "zstd --decompress -c",
+				Extension:     ".zst",
+			}
+			utils.InitializePipeThroughParameters(true, "zstd", 7)
 			resultProgram := utils.GetPipeThroughProgram()
 			structmatcher.ExpectStructsToMatch(&expectedProgram, &resultProgram)
 		})

--- a/utils/util.go
+++ b/utils/util.go
@@ -112,9 +112,11 @@ func ValidateFullPath(path string) error {
 func ValidateCompressionTypeAndLevel(compressionType string, compressionLevel int) error {
 	minAllowedCompressionLevels := map[string]int{
 		"gzip": 1,
+		"zstd": 1,
 	}
 	maxAllowedCompressionLevels := map[string]int{
 		"gzip": 9,
+		"zstd": 19,
 	}
 
 	if maxAllowedLevel, ok := maxAllowedCompressionLevels[compressionType]; ok {

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -140,6 +140,24 @@ var _ = Describe("utils/util tests", func() {
 			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
 			Expect(err).To(MatchError("unknown compression type ''"))
 		})
+		It("validates a compression type 'zstd' and a level between 1 and 19", func() {
+			compressType := "zstd"
+			compressLevel := 11
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+		It("panics if given a compression type 'zstd' and a compression level < 1", func() {
+			compressType := "zstd"
+			compressLevel := 0
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(MatchError("compression type 'zstd' only allows compression levels between 1 and 19, but the provided level is 0"))
+		})
+		It("panics if given a compression type 'gzip' and a compression level > 19", func() {
+			compressType := "zstd"
+			compressLevel := 20
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(MatchError("compression type 'zstd' only allows compression levels between 1 and 19, but the provided level is 20"))
+		})
 	})
 	Describe("UnquoteIdent", func() {
 		It("returns unchanged ident when passed a single char", func() {


### PR DESCRIPTION
Support ZSTD compression type in backup, restore, and helper modules.

https://pkg.go.dev/github.com/klauspost/compress/zstd is used as the provider of ZSTD implementation in `backup_helper`.

Add test cases for `zstd` compression type.