### PR TITLE
ADBDEV-1731. Implement `zstd` compression support

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -72,7 +72,7 @@ func DoSetup() {
 	}
 	globalTOC = &toc.TOC{}
 	globalTOC.InitializeMetadataEntryMap()
-	utils.InitializePipeThroughParameters(!MustGetFlagBool(options.NO_COMPRESSION), MustGetFlagInt(options.COMPRESSION_LEVEL))
+	utils.InitializePipeThroughParameters(!MustGetFlagBool(options.NO_COMPRESSION), MustGetFlagString(options.COMPRESSION_TYPE), MustGetFlagInt(options.COMPRESSION_LEVEL))
 	getQuotedRoleNames(connectionPool)
 
 	pluginConfigFlag := MustGetFlagString(options.PLUGIN_CONFIG)
@@ -268,7 +268,7 @@ func backupData(tables []Table) {
 		}
 		utils.WriteOidListToSegments(oidList, globalCluster, globalFPInfo)
 		utils.CreateFirstSegmentPipeOnAllHosts(oidList[0], globalCluster, globalFPInfo)
-		compressStr := fmt.Sprintf(" --compression-level %d", MustGetFlagInt(options.COMPRESSION_LEVEL))
+		compressStr := fmt.Sprintf(" --compression-level %d --compression-type %s", MustGetFlagInt(options.COMPRESSION_LEVEL), MustGetFlagString(options.COMPRESSION_TYPE))
 		if MustGetFlagBool(options.NO_COMPRESSION) {
 			compressStr = " --compression-level 0"
 		}

--- a/backup/validate.go
+++ b/backup/validate.go
@@ -99,6 +99,7 @@ func validateFlagCombinations(flags *pflag.FlagSet) {
 	options.CheckExclusiveFlags(flags, options.EXCLUDE_SCHEMA, options.EXCLUDE_SCHEMA_FILE, options.EXCLUDE_RELATION, options.INCLUDE_RELATION, options.EXCLUDE_RELATION_FILE, options.INCLUDE_RELATION_FILE)
 	options.CheckExclusiveFlags(flags, options.JOBS, options.METADATA_ONLY, options.SINGLE_DATA_FILE)
 	options.CheckExclusiveFlags(flags, options.METADATA_ONLY, options.LEAF_PARTITION_DATA)
+	options.CheckExclusiveFlags(flags, options.NO_COMPRESSION, options.COMPRESSION_TYPE)
 	options.CheckExclusiveFlags(flags, options.NO_COMPRESSION, options.COMPRESSION_LEVEL)
 	options.CheckExclusiveFlags(flags, options.PLUGIN_CONFIG, options.BACKUP_DIR)
 	if MustGetFlagString(options.FROM_TIMESTAMP) != "" && !MustGetFlagBool(options.INCREMENTAL) {
@@ -114,7 +115,7 @@ func validateFlagValues() {
 	gplog.FatalOnError(err)
 	err = utils.ValidateFullPath(MustGetFlagString(options.PLUGIN_CONFIG))
 	gplog.FatalOnError(err)
-	err = utils.ValidateCompressionLevel(MustGetFlagInt(options.COMPRESSION_LEVEL))
+	err = utils.ValidateCompressionTypeAndLevel(MustGetFlagString(options.COMPRESSION_TYPE), MustGetFlagInt(options.COMPRESSION_LEVEL))
 	gplog.FatalOnError(err)
 	if MustGetFlagString(options.FROM_TIMESTAMP) != "" && !filepath.IsValidTimestamp(MustGetFlagString(options.FROM_TIMESTAMP)) {
 		gplog.Fatal(errors.Errorf("Timestamp %s is invalid.  Timestamps must be in the format YYYYMMDDHHMMSS.",

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -80,6 +80,7 @@ func NewBackupConfig(dbName string, dbVersion string, backupVersion string, plug
 		BackupDir:             MustGetFlagString(options.BACKUP_DIR),
 		BackupVersion:         backupVersion,
 		Compressed:            !MustGetFlagBool(options.NO_COMPRESSION),
+		CompressionType:       MustGetFlagString(options.COMPRESSION_TYPE),
 		DatabaseName:          dbName,
 		DatabaseVersion:       dbVersion,
 		DataOnly:              MustGetFlagBool(options.DATA_ONLY),

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/greenplum-db/gp-common-go-libs v1.0.5-0.20201005232358-ee3f0135881b
 	github.com/jackc/pgconn v1.7.0
+	github.com/klauspost/compress v1.13.1
 	github.com/lib/pq v1.3.0
 	github.com/mattn/go-runewidth v0.0.8 // indirect
 	github.com/nightlyone/lockfile v0.0.0-20200124072040-edb130adc195

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
+github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
@@ -108,6 +110,8 @@ github.com/jackc/puddle v1.1.2/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dv
 github.com/jmoiron/sqlx v0.0.0-20180614180643-0dae4fefe7c0 h1:5B0uxl2lzNRVkJVg+uGHxWtRt4C0Wjc6kJKo5XYx8xE=
 github.com/jmoiron/sqlx v0.0.0-20180614180643-0dae4fefe7c0/go.mod h1:IiEW3SEiiErVyFdH8NTuWjSifiEQKUoyK3LNqr2kCHU=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.13.1 h1:wXr2uRxZTJXHLly6qhJabee5JqIhTRoLBhDOA74hDEQ=
+github.com/klauspost/compress v1.13.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/helper/backup_helper.go
+++ b/helper/backup_helper.go
@@ -137,6 +137,10 @@ func getBackupPipeWriter() (pipe BackupPipeWriterCloser, writeCmd *exec.Cmd, err
 		pipe, err = NewGZipBackupPipeWriterCloser(writeHandle, *compressionLevel)
 		return
 	}
+	if *compressionType == "zstd" {
+		pipe, err = NewZSTDBackupPipeWriterCloser(writeHandle, *compressionLevel)
+		return
+	}
 
 	writeHandle.Close()
 	return nil, nil, fmt.Errorf("unknown compression type '%s' (compression level %d)", *compressionType, *compressionLevel)

--- a/helper/backup_helper_pipes.go
+++ b/helper/backup_helper_pipes.go
@@ -1,0 +1,60 @@
+package helper
+
+import (
+	"bufio"
+	"compress/gzip"
+	"io"
+)
+
+type BackupPipeWriterCloser interface {
+	io.Writer
+	io.Closer
+}
+
+type CommonBackupPipeWriterCloser struct {
+	writeHandle io.WriteCloser
+	bufIoWriter *bufio.Writer
+	finalWriter io.Writer
+}
+
+func (cPipe CommonBackupPipeWriterCloser) Write(p []byte) (n int, err error) {
+	return cPipe.finalWriter.Write(p)
+}
+
+// Never returns error, suppressing them instead
+func (cPipe CommonBackupPipeWriterCloser) Close() error {
+	_ = cPipe.bufIoWriter.Flush()
+	_ = cPipe.writeHandle.Close()
+	return nil
+}
+
+func NewCommonBackupPipeWriterCloser(writeHandle io.WriteCloser) (cPipe CommonBackupPipeWriterCloser) {
+	cPipe.writeHandle = writeHandle
+	cPipe.bufIoWriter = bufio.NewWriter(cPipe.writeHandle)
+	cPipe.finalWriter = cPipe.bufIoWriter
+	return
+}
+
+type GZipBackupPipeWriterCloser struct {
+	cPipe      CommonBackupPipeWriterCloser
+	gzipWriter *gzip.Writer
+}
+
+func (gzPipe GZipBackupPipeWriterCloser) Write(p []byte) (n int, err error) {
+	return gzPipe.gzipWriter.Write(p)
+}
+
+// Returns errors from underlying common writer only
+func (gzPipe GZipBackupPipeWriterCloser) Close() error {
+	_ = gzPipe.gzipWriter.Close()
+	return gzPipe.cPipe.Close()
+}
+
+func NewGZipBackupPipeWriterCloser(writeHandle io.WriteCloser, compressLevel int) (gzPipe GZipBackupPipeWriterCloser, err error) {
+	gzPipe.cPipe = NewCommonBackupPipeWriterCloser(writeHandle)
+	gzPipe.gzipWriter, err = gzip.NewWriterLevel(gzPipe.cPipe.bufIoWriter, compressLevel)
+	if err != nil {
+		gzPipe.cPipe.Close()
+	}
+	return
+}

--- a/helper/backup_helper_pipes.go
+++ b/helper/backup_helper_pipes.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"compress/gzip"
 	"io"
+
+	"github.com/klauspost/compress/zstd"
 )
 
 type BackupPipeWriterCloser interface {
@@ -55,6 +57,30 @@ func NewGZipBackupPipeWriterCloser(writeHandle io.WriteCloser, compressLevel int
 	gzPipe.gzipWriter, err = gzip.NewWriterLevel(gzPipe.cPipe.bufIoWriter, compressLevel)
 	if err != nil {
 		gzPipe.cPipe.Close()
+	}
+	return
+}
+
+type ZSTDBackupPipeWriterCloser struct {
+	cPipe       CommonBackupPipeWriterCloser
+	zstdEncoder *zstd.Encoder
+}
+
+func (zstdPipe ZSTDBackupPipeWriterCloser) Write(p []byte) (n int, err error) {
+	return zstdPipe.zstdEncoder.Write(p)
+}
+
+// Returns errors from underlying common writer only
+func (zstdPipe ZSTDBackupPipeWriterCloser) Close() error {
+	_ = zstdPipe.zstdEncoder.Close()
+	return zstdPipe.cPipe.Close()
+}
+
+func NewZSTDBackupPipeWriterCloser(writeHandle io.WriteCloser, compressLevel int) (zstdPipe ZSTDBackupPipeWriterCloser, err error) {
+	zstdPipe.cPipe = NewCommonBackupPipeWriterCloser(writeHandle)
+	zstdPipe.zstdEncoder, err = zstd.NewWriter(zstdPipe.cPipe.bufIoWriter, zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(compressLevel)))
+	if err != nil {
+		zstdPipe.cPipe.Close()
 	}
 	return
 }

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -43,6 +43,7 @@ var (
 var (
 	backupAgent      *bool
 	compressionLevel *int
+	compressionType  *string
 	content          *int
 	dataFile         *string
 	oidFile          *string
@@ -99,7 +100,8 @@ func InitializeGlobals() {
 
 	backupAgent = flag.Bool("backup-agent", false, "Use gpbackup_helper as an agent for backup")
 	content = flag.Int("content", -2, "Content ID of the corresponding segment")
-	compressionLevel = flag.Int("compression-level", 0, "The level of compression to use with gzip. O indicates no compression.")
+	compressionLevel = flag.Int("compression-level", 0, "The level of compression. O indicates no compression.")
+	compressionType = flag.String("compression-type", "gzip", "The type of compression. Valid values are 'gzip'")
 	dataFile = flag.String("data-file", "", "Absolute path to the data file")
 	oidFile = flag.String("oid-file", "", "Absolute path to the file containing a list of oids to restore")
 	onErrorContinue = flag.Bool("on-error-continue", false, "Continue restore even when encountering an error")
@@ -164,7 +166,6 @@ func flushAndCloseRestoreWriter() error {
 	}
 	return nil
 }
-
 
 /*
  * Shared helper functions

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -100,8 +100,8 @@ func InitializeGlobals() {
 
 	backupAgent = flag.Bool("backup-agent", false, "Use gpbackup_helper as an agent for backup")
 	content = flag.Int("content", -2, "Content ID of the corresponding segment")
-	compressionLevel = flag.Int("compression-level", 0, "The level of compression. O indicates no compression.")
-	compressionType = flag.String("compression-type", "gzip", "The type of compression. Valid values are 'gzip'")
+	compressionLevel = flag.Int("compression-level", 0, "The level of compression. O indicates no compression. Range of valid values depends on compression type")
+	compressionType = flag.String("compression-type", "gzip", "The type of compression. Valid values are 'gzip', 'zstd'")
 	dataFile = flag.String("data-file", "", "Absolute path to the data file")
 	oidFile = flag.String("oid-file", "", "Absolute path to the file containing a list of oids to restore")
 	onErrorContinue = flag.Bool("on-error-continue", false, "Continue restore even when encountering an error")

--- a/helper/restore_helper.go
+++ b/helper/restore_helper.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/greenplum-db/gpbackup/toc"
 	"github.com/greenplum-db/gpbackup/utils"
+	"github.com/klauspost/compress/zstd"
 	"github.com/pkg/errors"
 )
 
@@ -19,10 +20,11 @@ import (
  * Restore specific functions
  */
 type ReaderType string
+
 const (
-	SEEKABLE ReaderType = "seekable"	// reader which supports seek
-	NONSEEKABLE			= "discard"		// reader which is not seekable
-	SUBSET				= "subset"		// reader which operates on pre filtered data
+	SEEKABLE    ReaderType = "seekable" // reader which supports seek
+	NONSEEKABLE            = "discard"  // reader which is not seekable
+	SUBSET                 = "subset"   // reader which operates on pre filtered data
 )
 
 /* RestoreReader structure to wrap the underlying reader.
@@ -134,7 +136,7 @@ func doRestoreAgent() error {
 		}
 
 		log(fmt.Sprintf("Restoring table with oid %d", oid))
-		bytesRead, err = reader.copyData(int64(end-start))
+		bytesRead, err = reader.copyData(int64(end - start))
 		if err != nil {
 			// In case COPY FROM or copyN fails in the middle of a load. We
 			// need to update the lastByte with the amount of bytes that was
@@ -192,7 +194,7 @@ func getRestoreDataReader(toc *toc.SegmentTOC, oidList []int) (*RestoreReader, e
 			restoreReader.readerType = NONSEEKABLE
 		}
 	} else {
-		if *isFiltered && !strings.HasSuffix(*dataFile, ".gz") {
+		if *isFiltered && !strings.HasSuffix(*dataFile, ".gz") && !strings.HasSuffix(*dataFile, ".zst") {
 			// Seekable reader if backup is not compressed and filters are set
 			seekHandle, err = os.Open(*dataFile)
 			restoreReader.readerType = SEEKABLE
@@ -215,6 +217,12 @@ func getRestoreDataReader(toc *toc.SegmentTOC, oidList []int) (*RestoreReader, e
 			return nil, err
 		}
 		restoreReader.bufReader = bufio.NewReader(gzipReader)
+	} else if strings.HasSuffix(*dataFile, ".zst") {
+		zstdReader, err := zstd.NewReader(readHandle)
+		if err != nil {
+			return nil, err
+		}
+		restoreReader.bufReader = bufio.NewReader(zstdReader)
 	} else {
 		restoreReader.bufReader = bufio.NewReader(readHandle)
 	}
@@ -241,7 +249,7 @@ func getRestorePipeWriter(currentPipe string) (*bufio.Writer, *os.File, error) {
 	// adopting the new kernel, we must only use the bare essential methods Write() and
 	// Close() for the pipe to avoid an extra buffer read that can happen in error
 	// scenarios with --on-error-continue.
-	pipeWriter := bufio.NewWriter(struct{io.WriteCloser}{fileHandle})
+	pipeWriter := bufio.NewWriter(struct{ io.WriteCloser }{fileHandle})
 
 	return pipeWriter, fileHandle, nil
 }
@@ -253,7 +261,7 @@ func startRestorePluginCommand(toc *toc.SegmentTOC, oidList []int) (io.Reader, b
 		return nil, false, err
 	}
 	cmdStr := ""
-	if pluginConfig.CanRestoreSubset() && *isFiltered && !strings.HasSuffix(*dataFile, ".gz") {
+	if pluginConfig.CanRestoreSubset() && *isFiltered && !strings.HasSuffix(*dataFile, ".gz") && !strings.HasSuffix(*dataFile, ".zst") {
 		offsetsFile, _ := ioutil.TempFile("/tmp", "gprestore_offsets_")
 		defer func() {
 			offsetsFile.Close()

--- a/history/history.go
+++ b/history/history.go
@@ -29,6 +29,7 @@ type BackupConfig struct {
 	BackupDir             string
 	BackupVersion         string
 	Compressed            bool
+	CompressionType       string
 	DatabaseName          string
 	DatabaseVersion       string
 	DataOnly              bool

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -108,7 +108,7 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("runs backup gpbackup_helper with compression", func() {
-			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-level", "1", "--data-file", dataFileFullPath+".gz")
+			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-type", "gzip", "--compression-level", "1", "--data-file", dataFileFullPath+".gz")
 			writeToPipes(defaultData)
 			err := helperCmd.Wait()
 			printHelperLogOnError(err)
@@ -124,7 +124,7 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			assertBackupArtifacts(false, true)
 		})
 		It("runs backup gpbackup_helper with compression with plugin", func() {
-			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-level", "1", "--data-file", dataFileFullPath+".gz", "--plugin-config", pluginConfigPath)
+			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-type", "gzip", "--compression-level", "1", "--data-file", dataFileFullPath+".gz", "--plugin-config", pluginConfigPath)
 			writeToPipes(defaultData)
 			err := helperCmd.Wait()
 			printHelperLogOnError(err)

--- a/options/flag.go
+++ b/options/flag.go
@@ -52,8 +52,8 @@ const (
 
 func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.String(BACKUP_DIR, "", "The absolute path of the directory to which all backup files will be written")
-	flagSet.String(COMPRESSION_TYPE, "gzip", "Type of compression to use during data backup. Valid values are: 'gzip'")
-	flagSet.Int(COMPRESSION_LEVEL, 1, "Level of compression to use during data backup. Valid values are between 1 and 9.")
+	flagSet.String(COMPRESSION_TYPE, "gzip", "Type of compression to use during data backup. Valid values are 'gzip', 'zstd'")
+	flagSet.Int(COMPRESSION_LEVEL, 1, "Level of compression to use during data backup. Range of valid values depends on compression type")
 	flagSet.Bool(DATA_ONLY, false, "Only back up data, do not back up metadata")
 	flagSet.String(DBNAME, "", "The database to be backed up")
 	flagSet.Bool(DEBUG, false, "Print verbose and debug log messages")

--- a/options/flag.go
+++ b/options/flag.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	BACKUP_DIR            = "backup-dir"
+	COMPRESSION_TYPE      = "compression-type"
 	COMPRESSION_LEVEL     = "compression-level"
 	DATA_ONLY             = "data-only"
 	DBNAME                = "dbname"
@@ -51,6 +52,7 @@ const (
 
 func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.String(BACKUP_DIR, "", "The absolute path of the directory to which all backup files will be written")
+	flagSet.String(COMPRESSION_TYPE, "gzip", "Type of compression to use during data backup. Valid values are: 'gzip'")
 	flagSet.Int(COMPRESSION_LEVEL, 1, "Level of compression to use during data backup. Valid values are between 1 and 9.")
 	flagSet.Bool(DATA_ONLY, false, "Only back up data, do not back up metadata")
 	flagSet.String(DBNAME, "", "The database to be backed up")

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -295,10 +295,10 @@ restore status:      Success but non-fatal errors occurred. See log file .+ for 
 	})
 	Describe("SetBackupParamFromFlags", func() {
 		AfterEach(func() {
-			utils.InitializePipeThroughParameters(false, 0)
+			utils.InitializePipeThroughParameters(false, "", 0)
 		})
 		It("configures the Report struct correctly", func() {
-			utils.InitializePipeThroughParameters(true, 0)
+			utils.InitializePipeThroughParameters(true, "gzip", 0)
 			backupCmdFlags := pflag.NewFlagSet("gpbackup", pflag.ExitOnError)
 			backup.SetCmdFlags(backupCmdFlags)
 			err := backupCmdFlags.Set(options.INCLUDE_RELATION, "public.foobar")
@@ -315,6 +315,7 @@ restore status:      Success but non-fatal errors occurred. See log file .+ for 
 			structmatcher.ExpectStructsToMatch(history.BackupConfig{
 				BackupVersion:        "0.1.0",
 				Compressed:           true,
+				CompressionType:      "gzip",
 				DatabaseName:         "testdb",
 				DatabaseVersion:      "5.0.0 build test",
 				IncludeSchemas:       []string{},

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -21,11 +21,20 @@ var _ = Describe("restore/data tests", func() {
 			backup.SetPluginConfig(nil)
 			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "")
 		})
-		It("will restore a table from its own file with compression", func() {
+		It("will restore a table from its own file with gzip compression", func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "gzip", OutputCommand: "gzip -c -1", InputCommand: "gzip -d -c", Extension: ".gz"})
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz | gzip -d -c' WITH CSV DELIMITER ',' ON SEGMENT;")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz"
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from its own file with zstd compression", func() {
+			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "zstd", OutputCommand: "zstd --compress -1 -c", InputCommand: "zstd --decompress -c", Extension: ".zst"})
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst | zstd --decompress -c' WITH CSV DELIMITER ',' ON SEGMENT;")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst"
 			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
 
 			Expect(err).ShouldNot(HaveOccurred())
@@ -46,7 +55,7 @@ var _ = Describe("restore/data tests", func() {
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
-		It("will restore a table from its own file with compression using a plugin", func() {
+		It("will restore a table from its own file with gzip compression using a plugin", func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "gzip", OutputCommand: "gzip -c -1", InputCommand: "gzip -d -c", Extension: ".gz"})
 			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "/tmp/plugin_config")
 			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
@@ -55,6 +64,19 @@ var _ = Describe("restore/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from its own file with zstd compression using a plugin", func() {
+			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "zstd", OutputCommand: "zstd --compress -1 -c", InputCommand: "zstd --decompress -c", Extension: ".zst"})
+			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "/tmp/plugin_config")
+			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
+			restore.SetPluginConfig(&pluginConfig)
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM '/tmp/fake-plugin.sh restore_data /tmp/plugin_config <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst | zstd --decompress -c' WITH CSV DELIMITER ',' ON SEGMENT;")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst"
 			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
 
 			Expect(err).ShouldNot(HaveOccurred())

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -134,7 +134,7 @@ func SetMaxCsvLineLengthQuery(connectionPool *dbconn.DBConn) string {
 
 func InitializeBackupConfig() {
 	backupConfig = history.ReadConfigFile(globalFPInfo.GetConfigFilePath())
-	utils.InitializePipeThroughParameters(backupConfig.Compressed, 0)
+	utils.InitializePipeThroughParameters(backupConfig.Compressed, backupConfig.CompressionType, 0)
 	report.EnsureBackupVersionCompatibility(backupConfig.BackupVersion, version)
 	report.EnsureDatabaseVersionCompatibility(backupConfig.DatabaseVersion, connectionPool.Version)
 }

--- a/utils/compression.go
+++ b/utils/compression.go
@@ -13,11 +13,20 @@ type PipeThroughProgram struct {
 	Extension     string
 }
 
-func InitializePipeThroughParameters(compress bool, compressionLevel int) {
-	if compress {
-		pipeThroughProgram = PipeThroughProgram{Name: "gzip", OutputCommand: fmt.Sprintf("gzip -c -%d", compressionLevel), InputCommand: "gzip -d -c", Extension: ".gz"}
-	} else {
+func InitializePipeThroughParameters(compress bool, compressionType string, compressionLevel int) {
+	if !compress {
 		pipeThroughProgram = PipeThroughProgram{Name: "cat", OutputCommand: "cat -", InputCommand: "cat -", Extension: ""}
+		return
+	}
+
+	// backward compatibility for inputs without compressionType
+	if compressionType == "" {
+		compressionType = "gzip"
+	}
+
+	if compressionType == "gzip" {
+		pipeThroughProgram = PipeThroughProgram{Name: "gzip", OutputCommand: fmt.Sprintf("gzip -c -%d", compressionLevel), InputCommand: "gzip -d -c", Extension: ".gz"}
+		return
 	}
 }
 

--- a/utils/compression.go
+++ b/utils/compression.go
@@ -28,6 +28,11 @@ func InitializePipeThroughParameters(compress bool, compressionType string, comp
 		pipeThroughProgram = PipeThroughProgram{Name: "gzip", OutputCommand: fmt.Sprintf("gzip -c -%d", compressionLevel), InputCommand: "gzip -d -c", Extension: ".gz"}
 		return
 	}
+
+	if compressionType == "zstd" {
+		pipeThroughProgram = PipeThroughProgram{Name: "zstd", OutputCommand: fmt.Sprintf("zstd --compress -%d -c", compressionLevel), InputCommand: "zstd --decompress -c", Extension: ".zst"}
+		return
+	}
 }
 
 func GetPipeThroughProgram() PipeThroughProgram {

--- a/utils/compression_test.go
+++ b/utils/compression_test.go
@@ -43,7 +43,7 @@ var _ = Describe("utils/compression tests", func() {
 			resultProgram := utils.GetPipeThroughProgram()
 			structmatcher.ExpectStructsToMatch(&expectedProgram, &resultProgram)
 		})
-		It("initializes to use gzip when passed compression and a level", func() {
+		It("initializes to use gzip when passed compression type gzip and a level", func() {
 			originalProgram := utils.GetPipeThroughProgram()
 			defer utils.SetPipeThroughProgram(originalProgram)
 			expectedProgram := utils.PipeThroughProgram{
@@ -53,6 +53,19 @@ var _ = Describe("utils/compression tests", func() {
 				Extension:     ".gz",
 			}
 			utils.InitializePipeThroughParameters(true, "gzip", 7)
+			resultProgram := utils.GetPipeThroughProgram()
+			structmatcher.ExpectStructsToMatch(&expectedProgram, &resultProgram)
+		})
+		It("initializes to use zstd when passed compression type zstd and a level", func() {
+			originalProgram := utils.GetPipeThroughProgram()
+			defer utils.SetPipeThroughProgram(originalProgram)
+			expectedProgram := utils.PipeThroughProgram{
+				Name:          "zstd",
+				OutputCommand: "zstd --compress -7 -c",
+				InputCommand:  "zstd --decompress -c",
+				Extension:     ".zst",
+			}
+			utils.InitializePipeThroughParameters(true, "zstd", 7)
 			resultProgram := utils.GetPipeThroughProgram()
 			structmatcher.ExpectStructsToMatch(&expectedProgram, &resultProgram)
 		})

--- a/utils/compression_test.go
+++ b/utils/compression_test.go
@@ -39,7 +39,7 @@ var _ = Describe("utils/compression tests", func() {
 				InputCommand:  "cat -",
 				Extension:     "",
 			}
-			utils.InitializePipeThroughParameters(false, 3)
+			utils.InitializePipeThroughParameters(false, "", 3)
 			resultProgram := utils.GetPipeThroughProgram()
 			structmatcher.ExpectStructsToMatch(&expectedProgram, &resultProgram)
 		})
@@ -52,7 +52,7 @@ var _ = Describe("utils/compression tests", func() {
 				InputCommand:  "gzip -d -c",
 				Extension:     ".gz",
 			}
-			utils.InitializePipeThroughParameters(true, 7)
+			utils.InitializePipeThroughParameters(true, "gzip", 7)
 			resultProgram := utils.GetPipeThroughProgram()
 			structmatcher.ExpectStructsToMatch(&expectedProgram, &resultProgram)
 		})

--- a/utils/util.go
+++ b/utils/util.go
@@ -43,11 +43,11 @@ func RemoveFileIfExists(filename string) error {
 }
 
 func OpenFileForWrite(filename string) (*os.File, error) {
-	return os.OpenFile(filename, os.O_CREATE | os.O_TRUNC | os.O_WRONLY, 0644)
+	return os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 }
 
 func WriteToFileAndMakeReadOnly(filename string, contents []byte) error {
-	file, err := os.OpenFile(filename, os.O_CREATE | os.O_TRUNC | os.O_WRONLY, 0644)
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
@@ -109,10 +109,24 @@ func ValidateFullPath(path string) error {
 	return nil
 }
 
-func ValidateCompressionLevel(compressionLevel int) error {
-	if compressionLevel < 1 || compressionLevel > 9 {
-		return errors.Errorf("Compression level must be between 1 and 9")
+func ValidateCompressionTypeAndLevel(compressionType string, compressionLevel int) error {
+	minAllowedCompressionLevels := map[string]int{
+		"gzip": 1,
 	}
+	maxAllowedCompressionLevels := map[string]int{
+		"gzip": 9,
+	}
+
+	if maxAllowedLevel, ok := maxAllowedCompressionLevels[compressionType]; ok {
+		minAllowedLevel := minAllowedCompressionLevels[compressionType]
+
+		if compressionLevel < minAllowedLevel || compressionLevel > maxAllowedLevel {
+			return fmt.Errorf("compression type '%s' only allows compression levels between %d and %d, but the provided level is %d", compressionType, minAllowedLevel, maxAllowedLevel, compressionLevel)
+		}
+	} else {
+		return fmt.Errorf("unknown compression type '%s'", compressionType)
+	}
+
 	return nil
 }
 

--- a/utils/util.go
+++ b/utils/util.go
@@ -109,19 +109,21 @@ func ValidateFullPath(path string) error {
 	return nil
 }
 
+// A description of compression levels for some compression type
+type CompressionLevelsDescription struct {
+	Min int
+	Max int
+}
+
 func ValidateCompressionTypeAndLevel(compressionType string, compressionLevel int) error {
-	minAllowedCompressionLevels := map[string]int{
-		"gzip": 1,
-	}
-	maxAllowedCompressionLevels := map[string]int{
-		"gzip": 9,
+	compressionLevelsForType := map[string]CompressionLevelsDescription{
+		"gzip": {Min: 1, Max: 9},
+		"zstd": {Min: 1, Max: 19},
 	}
 
-	if maxAllowedLevel, ok := maxAllowedCompressionLevels[compressionType]; ok {
-		minAllowedLevel := minAllowedCompressionLevels[compressionType]
-
-		if compressionLevel < minAllowedLevel || compressionLevel > maxAllowedLevel {
-			return fmt.Errorf("compression type '%s' only allows compression levels between %d and %d, but the provided level is %d", compressionType, minAllowedLevel, maxAllowedLevel, compressionLevel)
+	if levelsDescription, ok := compressionLevelsForType[compressionType]; ok {
+		if compressionLevel < levelsDescription.Min || compressionLevel > levelsDescription.Max {
+			return fmt.Errorf("compression type '%s' only allows compression levels between %d and %d, but the provided level is %d", compressionType, levelsDescription.Min, levelsDescription.Max, compressionLevel)
 		}
 	} else {
 		return fmt.Errorf("unknown compression type '%s'", compressionType)

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -140,6 +140,24 @@ var _ = Describe("utils/util tests", func() {
 			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
 			Expect(err).To(MatchError("unknown compression type ''"))
 		})
+		It("validates a compression type 'zstd' and a level between 1 and 19", func() {
+			compressType := "zstd"
+			compressLevel := 11
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+		It("panics if given a compression type 'zstd' and a compression level < 1", func() {
+			compressType := "zstd"
+			compressLevel := 0
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(MatchError("compression type 'zstd' only allows compression levels between 1 and 19, but the provided level is 0"))
+		})
+		It("panics if given a compression type 'gzip' and a compression level > 19", func() {
+			compressType := "zstd"
+			compressLevel := 20
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(MatchError("compression type 'zstd' only allows compression levels between 1 and 19, but the provided level is 20"))
+		})
 	})
 	Describe("UnquoteIdent", func() {
 		It("returns unchanged ident when passed a single char", func() {

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -103,21 +103,42 @@ var _ = Describe("utils/util tests", func() {
 			utils.ValidateGPDBVersionCompatibility(connectionPool)
 		})
 	})
-	Describe("ValidateCompressionLevel", func() {
-		It("validates a compression level between 1 and 9", func() {
+	Describe("ValidateCompressionTypeAndLevel", func() {
+		It("validates a compression type 'gzip' and a level between 1 and 9", func() {
+			compressType := "gzip"
 			compressLevel := 5
-			err := utils.ValidateCompressionLevel(compressLevel)
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
 			Expect(err).To(Not(HaveOccurred()))
 		})
-		It("panics if given a compression level < 1", func() {
+		It("panics if given a compression type 'gzip' and a compression level < 1", func() {
+			compressType := "gzip"
 			compressLevel := 0
-			err := utils.ValidateCompressionLevel(compressLevel)
-			Expect(err).To(MatchError("Compression level must be between 1 and 9"))
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(MatchError("compression type 'gzip' only allows compression levels between 1 and 9, but the provided level is 0"))
 		})
-		It("panics if given a compression level > 9", func() {
+		It("panics if given a compression type 'gzip' and a compression level > 9", func() {
+			compressType := "gzip"
 			compressLevel := 11
-			err := utils.ValidateCompressionLevel(compressLevel)
-			Expect(err).To(MatchError("Compression level must be between 1 and 9"))
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(MatchError("compression type 'gzip' only allows compression levels between 1 and 9, but the provided level is 11"))
+		})
+		It("panics if given a compression type 'invalid' and a compression level > 0", func() {
+			compressType := "invalid"
+			compressLevel := 1
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(MatchError("unknown compression type 'invalid'"))
+		})
+		It("panics if given a compression type 'invalid' and a compression level < 0", func() {
+			compressType := "invalid"
+			compressLevel := -1
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(MatchError("unknown compression type 'invalid'"))
+		})
+		It("panics if given a compression type '' and a compression level > 0", func() {
+			compressType := ""
+			compressLevel := 1
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(MatchError("unknown compression type ''"))
 		})
 	})
 	Describe("UnquoteIdent", func() {


### PR DESCRIPTION
This PR duplicates https://github.com/arenadata/gpbackup/pull/2 for a different target branch (`arenadata/master`).

Add a flag to set compression type. `gzip` is the only currently supported value. To disable compression, `--no-compression` or `--compression-level 0` are to be set. `gzip` is also the default value for this parameter.

In `helper`, introduce `backup_helper_pipes.go`. This defines wrappers for buffer writers encapsulating various compression types (currently "no compression" and "gzip"). This allows to drop (somewhat) complex `Writer` closure algorithm in `backup_helper.go`.

Update `helper_test` and `compression_test` according to new changes.

Add support for `zstd` compression type. Update tests and run option descriptions accordingly.