### PR TITLE
ADBDEV-1953 - Handle arenadata suffix in version

### DIFF
--- a/arenadata/arenadata_helper.go
+++ b/arenadata/arenadata_helper.go
@@ -1,0 +1,41 @@
+package arenadata
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/pkg/errors"
+)
+
+func EnsureAdVersionCompatibility(backupVersion string, restoreVersion string) {
+	regex := *regexp.MustCompile(`_arenadata(\d+)`)
+	adBackup := regex.FindAllStringSubmatch(backupVersion, -1)[0][1]
+	adRestore := regex.FindAllStringSubmatch(restoreVersion, -1)[0][1]
+	if adRestore < adBackup {
+		gplog.Fatal(errors.Errorf("gprestore arenadata%s cannot restore a backup taken with gpbackup arenadata%s; please use gprestore arenadata%s or later.",
+			adRestore, adBackup, adBackup), "")
+	}
+}
+
+// fullVersion: gpbackup version + '_' + arenadata release + ('+' + gpbackup build)
+// example: 1.20.4_arenadata2+dev.1.g768b7e0 -> 1.20.4+dev.1.g768b7e0
+func GetOriginalVersion(fullVersion string) (pureVersion string, err error) {
+	base := strings.SplitN(fullVersion, "_", 2)
+	pureVersion = base[0]
+	adRelease := base[1]
+
+	if idx := strings.LastIndex(base[1], "+"); idx != -1 {
+		// dev version
+		build := base[1][idx:]
+		adRelease = base[1][:idx]
+		pureVersion += build
+	}
+
+	patern := regexp.MustCompile(`^arenadata\d+$`)
+	if adIndex := patern.FindStringIndex(adRelease); adIndex == nil {
+		return pureVersion, fmt.Errorf("Invalid format of arenadata build string %s\n", adRelease)
+	}
+	return
+}

--- a/arenadata/arenadata_helper.go
+++ b/arenadata/arenadata_helper.go
@@ -1,41 +1,42 @@
 package arenadata
 
 import (
-	"fmt"
 	"regexp"
-	"strings"
+	"strconv"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/pkg/errors"
 )
 
+var (
+	adPattern = regexp.MustCompile(`_arenadata(\d+)`)
+)
+
 func EnsureAdVersionCompatibility(backupVersion string, restoreVersion string) {
-	regex := *regexp.MustCompile(`_arenadata(\d+)`)
-	adBackup := regex.FindAllStringSubmatch(backupVersion, -1)[0][1]
-	adRestore := regex.FindAllStringSubmatch(restoreVersion, -1)[0][1]
+	var (
+		adBackup, adRestore int
+		err                 error
+	)
+	if strVersion := adPattern.FindAllStringSubmatch(backupVersion, -1); len(strVersion) > 0 {
+		adBackup, err = strconv.Atoi(strVersion[0][1])
+		gplog.FatalOnError(err)
+	} else {
+		gplog.Fatal(errors.Errorf("Invalid arenadata version format for gpbackup: %s", backupVersion), "")
+	}
+	if strVersion := adPattern.FindAllStringSubmatch(restoreVersion, -1); len(strVersion) > 0 {
+		adRestore, err = strconv.Atoi(strVersion[0][1])
+		gplog.FatalOnError(err)
+	} else {
+		gplog.Fatal(errors.Errorf("Invalid arenadata version format for gprestore: %s", restoreVersion), "")
+	}
 	if adRestore < adBackup {
-		gplog.Fatal(errors.Errorf("gprestore arenadata%s cannot restore a backup taken with gpbackup arenadata%s; please use gprestore arenadata%s or later.",
+		gplog.Fatal(errors.Errorf("gprestore arenadata%d cannot restore a backup taken with gpbackup arenadata%d; please use gprestore arenadata%d or later.",
 			adRestore, adBackup, adBackup), "")
 	}
 }
 
 // fullVersion: gpbackup version + '_' + arenadata release + ('+' + gpbackup build)
 // example: 1.20.4_arenadata2+dev.1.g768b7e0 -> 1.20.4+dev.1.g768b7e0
-func GetOriginalVersion(fullVersion string) (pureVersion string, err error) {
-	base := strings.SplitN(fullVersion, "_", 2)
-	pureVersion = base[0]
-	adRelease := base[1]
-
-	if idx := strings.LastIndex(base[1], "+"); idx != -1 {
-		// dev version
-		build := base[1][idx:]
-		adRelease = base[1][:idx]
-		pureVersion += build
-	}
-
-	patern := regexp.MustCompile(`^arenadata\d+$`)
-	if adIndex := patern.FindStringIndex(adRelease); adIndex == nil {
-		return pureVersion, fmt.Errorf("Invalid format of arenadata build string %s\n", adRelease)
-	}
-	return
+func GetOriginalVersion(fullVersion string) string {
+	return adPattern.ReplaceAllString(fullVersion, "")
 }

--- a/report/report.go
+++ b/report/report.go
@@ -15,6 +15,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gp-common-go-libs/iohelper"
 	"github.com/greenplum-db/gp-common-go-libs/operating"
+	"github.com/greenplum-db/gpbackup/arenadata"
 	"github.com/greenplum-db/gpbackup/history"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/pkg/errors"
@@ -289,6 +290,17 @@ func PrintObjectCounts(reportFile io.WriteCloser, objectCounts map[string]int) {
  * users will never use a +dev version in production.
  */
 func EnsureBackupVersionCompatibility(backupVersion string, restoreVersion string) {
+	if strings.Index(restoreVersion, "_arenadata") != -1 {
+		// arenadata build
+		var err error
+		if strings.Index(backupVersion, "_arenadata") != -1 {
+			arenadata.EnsureAdVersionCompatibility(backupVersion, restoreVersion)
+			backupVersion, err = arenadata.GetOriginalVersion(backupVersion)
+			gplog.FatalOnError(err)
+		}
+		restoreVersion, err = arenadata.GetOriginalVersion(restoreVersion)
+		gplog.FatalOnError(err)
+	}
 	backupSemVer, err := semver.Make(backupVersion)
 	gplog.FatalOnError(err)
 	restoreSemVer, err := semver.Make(restoreVersion)

--- a/report/report.go
+++ b/report/report.go
@@ -292,14 +292,11 @@ func PrintObjectCounts(reportFile io.WriteCloser, objectCounts map[string]int) {
 func EnsureBackupVersionCompatibility(backupVersion string, restoreVersion string) {
 	if strings.Index(restoreVersion, "_arenadata") != -1 {
 		// arenadata build
-		var err error
 		if strings.Index(backupVersion, "_arenadata") != -1 {
 			arenadata.EnsureAdVersionCompatibility(backupVersion, restoreVersion)
-			backupVersion, err = arenadata.GetOriginalVersion(backupVersion)
-			gplog.FatalOnError(err)
+			backupVersion = arenadata.GetOriginalVersion(backupVersion)
 		}
-		restoreVersion, err = arenadata.GetOriginalVersion(restoreVersion)
-		gplog.FatalOnError(err)
+		restoreVersion = arenadata.GetOriginalVersion(restoreVersion)
 	}
 	backupSemVer, err := semver.Make(backupVersion)
 	gplog.FatalOnError(err)

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -392,6 +392,17 @@ restore status:      Success but non-fatal errors occurred. See log file .+ for 
 		It("Does not panic if gpbackup version equals gprestore version", func() {
 			EnsureBackupVersionCompatibility("0.1.0", "0.1.0")
 		})
+		It("Panics if gpbackup arenadata version is greater than gprestore arenadata version", func() {
+			defer testhelper.ShouldPanicWithMessage("gprestore arenadata1 cannot restore a backup taken with gpbackup arenadata2; please use gprestore arenadata2 or later.")
+			EnsureBackupVersionCompatibility("1.20.4_arenadata2", "1.20.4_arenadata1")
+		})
+		It("Does not panic if gpbackup has upstream version, while gprestore has arenadata version", func() {
+			EnsureBackupVersionCompatibility("1.20.4", "1.20.4_arenadata2")
+		})
+		It("Panics if gpbackup has upstream version, gprestore has arenadata version and gpbackup version is greater", func() {
+			defer testhelper.ShouldPanicWithMessage("gprestore 1.20.4 cannot restore a backup taken with gpbackup 1.20.5; please use gprestore 1.20.5 or later.")
+			EnsureBackupVersionCompatibility("1.20.5", "1.20.4_arenadata2")
+		})
 	})
 	Describe("EnsureDatabaseVersionCompatibility", func() {
 		var restoreVersion dbconn.GPDBVersion

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -392,9 +392,18 @@ restore status:      Success but non-fatal errors occurred. See log file .+ for 
 		It("Does not panic if gpbackup version equals gprestore version", func() {
 			EnsureBackupVersionCompatibility("0.1.0", "0.1.0")
 		})
-		It("Panics if gpbackup arenadata version is greater than gprestore arenadata version", func() {
-			defer testhelper.ShouldPanicWithMessage("gprestore arenadata1 cannot restore a backup taken with gpbackup arenadata2; please use gprestore arenadata2 or later.")
-			EnsureBackupVersionCompatibility("1.20.4_arenadata2", "1.20.4_arenadata1")
+		It("Panics if gpbackup version is greater than gprestore version (arenadata build)", func() {
+			defer testhelper.ShouldPanicWithMessage("gprestore arenadata9 cannot restore a backup taken with gpbackup arenadata10; please use gprestore arenadata10 or later.")
+			EnsureBackupVersionCompatibility("1.21.0_arenadata10", "1.21.0_arenadata9")
+		})
+		It("Does not panic if gpbackup version is less than gprestore version (arenadata build)", func() {
+			EnsureBackupVersionCompatibility("1.21.0_arenadata9", "1.21.0_arenadata10")
+		})
+		It("Does not panic if gpbackup version equals gprestore version (arenadata build)", func() {
+			EnsureBackupVersionCompatibility("1.20.4_arenadata1", "1.20.4_arenadata1")
+		})
+		It("Does not panic if gpbackup version equals gprestore version (arenadata dev build)", func() {
+			EnsureBackupVersionCompatibility("1.20.4_arenadata2+dev.1.g768b7e0", "1.20.4_arenadata2+dev.1.g768b7e0")
 		})
 		It("Does not panic if gpbackup has upstream version, while gprestore has arenadata version", func() {
 			EnsureBackupVersionCompatibility("1.20.4", "1.20.4_arenadata2")


### PR DESCRIPTION
Add helper functions and slightly refactor main code in order to support arenadata version suffix + add the appropriate tests
(e.g. `gpbackup version + '_' + arenadata release + ('+' + gpbackup build)`)

Since now this fork only supports the following scenarios:
1. Backup with pivotal gpbackup build, restore with arenadata build
2. Backup with arenadata build, restore with arenadata build