### PR TITLE
ADBDEV-1918 Implement scripts ti run gpbackup tests

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -1,0 +1,3 @@
+FROM hub.adsw.io/library/gpdb6_regress:latest
+
+COPY . /home/gpadmin/go/src/github.com/greenplum-db/gpbackup

--- a/arenadata/README.md
+++ b/arenadata/README.md
@@ -1,0 +1,6 @@
+## How to run tests
+
+```bash
+docker build -t gpbackup:test -f arenadata/Dockerfile .
+docker run --rm -it --sysctl 'kernel.sem=500 1024000 200 4096' gpbackup:test bash -c "ssh-keygen -A && /usr/sbin/sshd && bash /home/gpadmin/go/src/github.com/greenplum-db/gpbackup/arenadata/run_gpbackup_tests.bash"
+```

--- a/arenadata/arenadata_helper.go
+++ b/arenadata/arenadata_helper.go
@@ -1,0 +1,42 @@
+package arenadata
+
+import (
+	"regexp"
+	"strconv"
+
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/pkg/errors"
+)
+
+var (
+	adPattern = regexp.MustCompile(`_arenadata(\d+)`)
+)
+
+func EnsureAdVersionCompatibility(backupVersion string, restoreVersion string) {
+	var (
+		adBackup, adRestore int
+		err                 error
+	)
+	if strVersion := adPattern.FindAllStringSubmatch(backupVersion, -1); len(strVersion) > 0 {
+		adBackup, err = strconv.Atoi(strVersion[0][1])
+		gplog.FatalOnError(err)
+	} else {
+		gplog.Fatal(errors.Errorf("Invalid arenadata version format for gpbackup: %s", backupVersion), "")
+	}
+	if strVersion := adPattern.FindAllStringSubmatch(restoreVersion, -1); len(strVersion) > 0 {
+		adRestore, err = strconv.Atoi(strVersion[0][1])
+		gplog.FatalOnError(err)
+	} else {
+		gplog.Fatal(errors.Errorf("Invalid arenadata version format for gprestore: %s", restoreVersion), "")
+	}
+	if adRestore < adBackup {
+		gplog.Fatal(errors.Errorf("gprestore arenadata%d cannot restore a backup taken with gpbackup arenadata%d; please use gprestore arenadata%d or later.",
+			adRestore, adBackup, adBackup), "")
+	}
+}
+
+// fullVersion: gpbackup version + '_' + arenadata release + ('+' + gpbackup build)
+// example: 1.20.4_arenadata2+dev.1.g768b7e0 -> 1.20.4+dev.1.g768b7e0
+func GetOriginalVersion(fullVersion string) string {
+	return adPattern.ReplaceAllString(fullVersion, "")
+}

--- a/arenadata/run_gpbackup_tests.bash
+++ b/arenadata/run_gpbackup_tests.bash
@@ -1,0 +1,19 @@
+#!/bin/bash -l
+
+set -eox pipefail
+
+source gpdb_src/concourse/scripts/common.bash
+install_and_configure_gpdb
+make -C gpdb_src
+make -C gpdb_src/contrib/dummy_seclabel/ install
+gpdb_src/concourse/scripts/setup_gpadmin_user.bash
+make_cluster
+
+su - gpadmin -c "
+source /usr/local/greenplum-db-devel/greenplum_path.sh;
+source ~/gpdb_src/gpAux/gpdemo/gpdemo-env.sh;
+gpconfig -c shared_preload_libraries -v dummy_seclabel;
+gpstop -ar;
+wget https://golang.org/dl/go1.14.15.linux-amd64.tar.gz;
+tar -C ~/ -xzf go1.14.15.linux-amd64.tar.gz;
+PATH=$PATH:~/go/bin GOPATH=~/go make depend build install test end_to_end -C go/src/github.com/greenplum-db/gpbackup/"

--- a/arenadata/run_gpbackup_tests.bash
+++ b/arenadata/run_gpbackup_tests.bash
@@ -4,7 +4,7 @@ set -eox pipefail
 
 source gpdb_src/concourse/scripts/common.bash
 install_and_configure_gpdb
-make -C gpdb_src
+make -C gpdb_src/src/test/regress/
 make -C gpdb_src/contrib/dummy_seclabel/ install
 gpdb_src/concourse/scripts/setup_gpadmin_user.bash
 make_cluster

--- a/report/report.go
+++ b/report/report.go
@@ -15,6 +15,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gp-common-go-libs/iohelper"
 	"github.com/greenplum-db/gp-common-go-libs/operating"
+	"github.com/greenplum-db/gpbackup/arenadata"
 	"github.com/greenplum-db/gpbackup/history"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/pkg/errors"
@@ -289,6 +290,14 @@ func PrintObjectCounts(reportFile io.WriteCloser, objectCounts map[string]int) {
  * users will never use a +dev version in production.
  */
 func EnsureBackupVersionCompatibility(backupVersion string, restoreVersion string) {
+	if strings.Index(restoreVersion, "_arenadata") != -1 {
+		// arenadata build
+		if strings.Index(backupVersion, "_arenadata") != -1 {
+			arenadata.EnsureAdVersionCompatibility(backupVersion, restoreVersion)
+			backupVersion = arenadata.GetOriginalVersion(backupVersion)
+		}
+		restoreVersion = arenadata.GetOriginalVersion(restoreVersion)
+	}
 	backupSemVer, err := semver.Make(backupVersion)
 	gplog.FatalOnError(err)
 	restoreSemVer, err := semver.Make(restoreVersion)

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -392,6 +392,26 @@ restore status:      Success but non-fatal errors occurred. See log file .+ for 
 		It("Does not panic if gpbackup version equals gprestore version", func() {
 			EnsureBackupVersionCompatibility("0.1.0", "0.1.0")
 		})
+		It("Panics if gpbackup version is greater than gprestore version (arenadata build)", func() {
+			defer testhelper.ShouldPanicWithMessage("gprestore arenadata9 cannot restore a backup taken with gpbackup arenadata10; please use gprestore arenadata10 or later.")
+			EnsureBackupVersionCompatibility("1.21.0_arenadata10", "1.21.0_arenadata9")
+		})
+		It("Does not panic if gpbackup version is less than gprestore version (arenadata build)", func() {
+			EnsureBackupVersionCompatibility("1.21.0_arenadata9", "1.21.0_arenadata10")
+		})
+		It("Does not panic if gpbackup version equals gprestore version (arenadata build)", func() {
+			EnsureBackupVersionCompatibility("1.20.4_arenadata1", "1.20.4_arenadata1")
+		})
+		It("Does not panic if gpbackup version equals gprestore version (arenadata dev build)", func() {
+			EnsureBackupVersionCompatibility("1.20.4_arenadata2+dev.1.g768b7e0", "1.20.4_arenadata2+dev.1.g768b7e0")
+		})
+		It("Does not panic if gpbackup has upstream version, while gprestore has arenadata version", func() {
+			EnsureBackupVersionCompatibility("1.20.4", "1.20.4_arenadata2")
+		})
+		It("Panics if gpbackup has upstream version, gprestore has arenadata version and gpbackup version is greater", func() {
+			defer testhelper.ShouldPanicWithMessage("gprestore 1.20.4 cannot restore a backup taken with gpbackup 1.20.5; please use gprestore 1.20.5 or later.")
+			EnsureBackupVersionCompatibility("1.20.5", "1.20.4_arenadata2")
+		})
 	})
 	Describe("EnsureDatabaseVersionCompatibility", func() {
 		var restoreVersion dbconn.GPDBVersion


### PR DESCRIPTION
We need to implement several improvements to make it possible to run
upstream test suite on top of our fork:

1. We need a separate script that runs the test suite inside a container with gpdb demo cluster
2. We need modification of version processing logic to use our own versioning system with patch number in arenadata-suffix.