### PR TITLE
ADBDEV-2049 Prohibit inclusion of leaf partitions without --leaf-partition-data

### DIFF
--- a/backup/validate.go
+++ b/backup/validate.go
@@ -88,6 +88,9 @@ func ValidateTablesExist(conn *dbconn.DBConn, tableList []string, excludeSet boo
 		if partTableMap[tableOid].Level == "i" {
 			gplog.Fatal(nil, "Cannot filter on %s, as it is an intermediate partition table.  Only parent partition tables and leaf partition tables may be specified.", table)
 		}
+		if partTableMap[tableOid].Level == "l" && !MustGetFlagBool(options.LEAF_PARTITION_DATA) {
+			gplog.Fatal(nil, "--leaf-partition-data flag must be specified to filter on %s, as it is a leaf partition table.", table)
+		}
 	}
 }
 

--- a/backup/validate_test.go
+++ b/backup/validate_test.go
@@ -150,6 +150,7 @@ var _ = Describe("backup/validate tests", func() {
 				partitionTables.AddRow("1", "l", "root")
 				mock.ExpectQuery("SELECT (.*)").WillReturnRows(partitionTables)
 				filterList = []string{"public.table1"}
+				_ = cmdFlags.Set(options.LEAF_PARTITION_DATA, "true")
 				backup.ValidateTablesExist(connectionPool, filterList, false)
 			})
 			It("panics if given an intermediate partition table and --leaf-partition-data is set", func() {
@@ -177,6 +178,19 @@ var _ = Describe("backup/validate tests", func() {
 				mock.ExpectQuery("SELECT (.*)").WillReturnRows(partitionTables)
 				filterList = []string{"public.table1"}
 				defer testhelper.ShouldPanicWithMessage("Cannot filter on public.table1, as it is an intermediate partition table.  Only parent partition tables and leaf partition tables may be specified.")
+				backup.ValidateTablesExist(connectionPool, filterList, false)
+			})
+			It("panics if given a leaf partition table and --leaf-partition-data is not set", func() {
+				// Added to handle call to `quote_ident`
+				schemaAndTable.AddRow("public", "table1")
+				mock.ExpectQuery("SELECT (.*)").WillReturnRows(schemaAndTable)
+				//
+				tableRows.AddRow("1", "public.table1")
+				mock.ExpectQuery("SELECT (.*)").WillReturnRows(tableRows)
+				partitionTables.AddRow("1", "l", "root")
+				mock.ExpectQuery("SELECT (.*)").WillReturnRows(partitionTables)
+				filterList = []string{"public.table1"}
+				defer testhelper.ShouldPanicWithMessage("--leaf-partition-data flag must be specified to filter on public.table1, as it is a leaf partition table.")
 				backup.ValidateTablesExist(connectionPool, filterList, false)
 			})
 		})


### PR DESCRIPTION
There is a potential situation, when data in a partition table is backed up and restored twice:
```
adb=# CREATE TABLE rank25 (id int, rank int, year int, gender 
char(1), count int)
DISTRIBUTED BY (id)
PARTITION BY RANGE (year)
( START (2006) END (2016) EVERY (1), 
  DEFAULT PARTITION extra );

adb=# insert into rank25 values (1, 1, 2006, 'M', 1) 
 
 adb=# select * from rank25;
 id | rank | year | gender | count 
----+------+------+--------+-------
  1 |    1 | 2006 | M      |     1
(1 row)

adb=# select * from public.rank25_1_prt_2;
 id | rank | year | gender | count 
----+------+------+--------+-------
  1 |    1 | 2006 | M      |     1
(1 row)

adb=# create database kek;

$ gpbackup --dbname adb --include-table public.rank25 --include-table public.rank25_1_prt_2
...
20210910:09:56:10 gpbackup:gpadmin:hc-sdw2:007986-[DEBUG]:-Writing data for table public.rank25 to file (table 1 of 2)
20210910:09:56:10 gpbackup:gpadmin:hc-sdw2:007986-[DEBUG]:-Worker 0: COPY public.rank25 TO PROGRAM 'gzip -c -1 > <SEG_DATA_DIR>/backups/20210910/20210910095146/gpbackup_<SEGID>_20210910095146_8331530.gz' 
WITH CSV DELIMITER ',' ON SEGMENT IGNORE EXTERNAL PARTITIONS;
20210910:09:56:11 gpbackup:gpadmin:hc-sdw2:007986-[DEBUG]:-Writing data for table public.rank25_1_prt_2 to file (table 2 of 2)
20210910:09:56:11 gpbackup:gpadmin:hc-sdw2:007986-[DEBUG]:-Worker 0: COPY public.rank25_1_prt_2 TO PROGRAM 'gzip -c -1 > <SEG_DATA_DIR>/backups/20210910/20210910095146/gpbackup_<SEGID>_20210910095146_8331
537.gz' WITH CSV DELIMITER ',' ON SEGMENT IGNORE EXTERNAL PARTITIONS;
...
$ gprestore --timestamp 20210910095146 --redirect-db kek

kek=# select * from rank25;
 id | rank | year | gender | count 
----+------+------+--------+-------
  1 |    1 | 2006 | M      |     1
  1 |    1 | 2006 | M      |     1
(2 rows)

kek=# select * from public.rank25_1_prt_2;
 id | rank | year | gender | count 
----+------+------+--------+-------
  1 |    1 | 2006 | M      |     1
  1 |    1 | 2006 | M      |     1
(2 rows) 
```
Consequently, it is necessary to force usage of --leaf-partition-data flag, otherwise
gpbackup executes `COPY` operation for both: parent and leaf partition tables.