### PR TITLE
ADBDEV-2126 1.21.1-sync

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -119,8 +119,11 @@ func DoBackup() {
 
 	gplog.Info("Gathering table state information")
 	metadataTables, dataTables := RetrieveAndProcessTables()
-	if !(MustGetFlagBool(options.METADATA_ONLY) || MustGetFlagBool(options.DATA_ONLY)) {
+	// This must be a full backup with --leaf-parition-data to query for incremental metadata
+	if !(MustGetFlagBool(options.METADATA_ONLY) || MustGetFlagBool(options.DATA_ONLY)) && MustGetFlagBool(options.LEAF_PARTITION_DATA) {
 		backupIncrementalMetadata()
+	} else {
+		gplog.Verbose("Skipping query for incremental metadata.")
 	}
 	CheckTablesContainData(dataTables)
 	metadataFilename := globalFPInfo.GetMetadataFilePath()


### PR DESCRIPTION
As an optimization step, we can skip gathering information for
incremental metadata when the --leaf-partition-data flag is not
specified. This is because we do not support taking incremental backups
on full backups without the --leaf-partition-data flag.

Co-authored-by: Kevin Yeap <kyeap@vmware.com>
Co-authored-by: Shivram Mani <shivram.mani@gmail.com>