### PR TITLE
ADBDEV-2183

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -119,13 +119,18 @@ func DoBackup() {
 
 	gplog.Info("Gathering table state information")
 	metadataTables, dataTables := RetrieveAndProcessTables()
+	dataTables, numExtOrForeignTables := GetBackupDataSet(dataTables)
+	if len(dataTables) == 0 {
+		gplog.Warn("No tables in backup set contain data. Performing metadata-only backup instead.")
+		backupReport.MetadataOnly = true
+	}
 	// This must be a full backup with --leaf-parition-data to query for incremental metadata
 	if !(MustGetFlagBool(options.METADATA_ONLY) || MustGetFlagBool(options.DATA_ONLY)) && MustGetFlagBool(options.LEAF_PARTITION_DATA) {
 		backupIncrementalMetadata()
 	} else {
 		gplog.Verbose("Skipping query for incremental metadata.")
 	}
-	CheckTablesContainData(dataTables)
+
 	metadataFilename := globalFPInfo.GetMetadataFilePath()
 	gplog.Info("Metadata will be written to %s", metadataFilename)
 	metadataFile := utils.NewFileWithByteCountFromFile(metadataFilename)
@@ -162,6 +167,7 @@ func DoBackup() {
 		backupReport.RestorePlan = PopulateRestorePlan(backupSetTables, targetBackupRestorePlan, dataTables)
 		backupData(backupSetTables)
 	}
+	printDataBackupWarnings(numExtOrForeignTables)
 	if MustGetFlagBool(options.WITH_STATS) {
 		backupStatistics(metadataTables)
 	}
@@ -265,9 +271,7 @@ func backupData(tables []Table) {
 		utils.VerifyHelperVersionOnSegments(version, globalCluster)
 		oidList := make([]string, 0, len(tables))
 		for _, table := range tables {
-			if !table.SkipDataBackup() {
-				oidList = append(oidList, fmt.Sprintf("%d", table.Oid))
-			}
+			oidList = append(oidList, fmt.Sprintf("%d", table.Oid))
 		}
 		utils.WriteOidListToSegments(oidList, globalCluster, globalFPInfo)
 		utils.CreateFirstSegmentPipeOnAllHosts(oidList[0], globalCluster, globalFPInfo)

--- a/backup/data.go
+++ b/backup/data.go
@@ -110,13 +110,7 @@ func BackupSingleTableData(table Table, rowsCopiedMap map[uint32]int64, counters
 }
 
 func backupDataForAllTables(tables []Table) []map[uint32]int64 {
-	var numExtOrForeignTables int64
-	for _, table := range tables {
-		if table.SkipDataBackup() {
-			numExtOrForeignTables++
-		}
-	}
-	counters := BackupProgressCounters{NumRegTables: 0, TotalRegTables: int64(len(tables)) - numExtOrForeignTables}
+	counters := BackupProgressCounters{NumRegTables: 0, TotalRegTables: int64(len(tables))}
 	counters.ProgressBar = utils.NewProgressBar(int(counters.TotalRegTables), "Tables backed up: ", utils.PB_INFO)
 	counters.ProgressBar.Start()
 	rowsCopiedMaps := make([]map[uint32]int64, connectionPool.NumConns)
@@ -141,10 +135,6 @@ func backupDataForAllTables(tables []Table) []map[uint32]int64 {
 					return
 				}
 
-				if table.SkipDataBackup() {
-					gplog.Verbose("Skipping data backup of table %s because it is either an external or foreign table.", table.FQN())
-					continue
-				}
 				// If a random external SQL command had queued an AccessExclusiveLock acquisition request
 				// against this next table, the --job worker thread would deadlock on the COPY attempt.
 				// To prevent gpbackup from hanging, we attempt to acquire an AccessShareLock on the
@@ -225,7 +215,6 @@ func backupDataForAllTables(tables []Table) []map[uint32]int64 {
 	}
 
 	counters.ProgressBar.Finish()
-	printDataBackupWarnings(numExtOrForeignTables)
 	return rowsCopiedMaps
 }
 
@@ -236,16 +225,22 @@ func printDataBackupWarnings(numExtTables int64) {
 	}
 }
 
-func CheckTablesContainData(tables []Table) {
+// Remove external/foreign tables from the data backup set
+func GetBackupDataSet(tables []Table) ([]Table, int64) {
+	var backupDataSet []Table
+	var numExtOrForeignTables int64
+
 	if !backupReport.MetadataOnly {
 		for _, table := range tables {
 			if !table.SkipDataBackup() {
-				return
+				backupDataSet = append(backupDataSet, table)
+			} else {
+				gplog.Verbose("Skipping data backup of table %s because it is either an external or foreign table.", table.FQN())
+				numExtOrForeignTables++
 			}
 		}
-		gplog.Warn("No tables in backup set contain data. Performing metadata-only backup instead.")
-		backupReport.MetadataOnly = true
 	}
+	return backupDataSet, numExtOrForeignTables
 }
 
 // Acquire AccessShareLock on a table with NOWAIT option. If we are unable to acquire


### PR DESCRIPTION
There is a potential unhandled 'out of range' error in backup process:

1. Create new db
2. Create AO table
3. Create external table 
4. Run gpbackup for the new db with the following params: `--leaf-partition-data`
5. Right after that (with no data change) run gpbackup for the same db with the following params:` --leaf-partition-data  --incremental`

This results in:

> runtime error: index out of range [0] with length 0: goroutine 1 [running]:
...
        /opt/go/src/runtime/panic.go:969 +0x1b9
github.com/greenplum-db/gpbackup/backup.backupData(0xc000d1e000, 0x18, 0x26)
        /home/jenkins/ci/bigtop/build/gpbackup/rpm/BUILD/gpbackup-1.20.4_arenadata1/src/github.com/greenplum-db/backup/**backup.go:270** +0x93c
github.com/greenplum-db/gpbackup/backup.DoBackup()