### PR TITLE
ADBDEV-2901 Fix order of restoring metadata 

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -226,10 +226,10 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 	objects := make([]Sortable, 0)
 	metadataMap := make(MetadataMap)
 
+	objects = append(objects, convertToSortableSlice(tables)...)
 	if !tableOnly {
 		functions, funcInfoMap = retrieveFunctions(&objects, metadataMap)
 	}
-	objects = append(objects, convertToSortableSlice(tables)...)
 	relationMetadata := GetMetadataForObjectType(connectionPool, TYPE_RELATION)
 	addToMetadataMap(relationMetadata, metadataMap)
 

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
@@ -83,6 +84,24 @@ var (
 type Sortable interface {
 	FQN() string
 	GetUniqueID() UniqueID
+}
+
+type Sortables []Sortable
+
+func (s Sortables) Len() int {
+	return len(s)
+}
+func (s Sortables) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s Sortables) Less(i, j int) bool {
+	return s[i].GetUniqueID().Oid < s[j].GetUniqueID().Oid
+}
+
+func SortByOid(sortables []Sortable) []Sortable {
+	s := Sortables(sortables)
+	sort.Sort(s)
+	return []Sortable(s)
 }
 
 func TopologicalSort(slice []Sortable, dependencies DependencyMap) []Sortable {

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -566,6 +566,7 @@ func backupDependentObjects(metadataFile *utils.FileWithByteCount, tables []Tabl
 
 	gplog.Verbose("Writing CREATE statements for dependent objects to metadata file")
 
+	sortables = SortByOid(sortables)
 	backupSet := createBackupSet(sortables)
 	relevantDeps := GetDependencies(connectionPool, backupSet)
 	if connectionPool.Version.Is("4") && !tableOnly {


### PR DESCRIPTION
```
CREATE TABLE mytable (
   id integer PRIMARY KEY,
   name text,
   fromdate timestamp with time zone NOT NULL
);
 
CREATE OR REPLACE FUNCTION myfunc(arg mytable[]) RETURNS void
   LANGUAGE plpgsql IMMUTABLE STRICT AS
$$DECLARE
   t mytable;
BEGIN
   FOREACH t IN ARRAY arg LOOP
      RAISE NOTICE 'id = %', t.id;
   END LOOP;
END;$$;
```
If we create a function that recieves a set of rows as parameter, then try to backup and restore it, we can get an error:
```
LANGUAGE plpgsql NO SQL IMMUTABLE STRICT; Error was: ERROR: type public.mytable[] does not exist (SQLSTATE 42704)
```
The error says that we can't create a table which recieves a set of rows of an unknown table. That error occurs because gpbackup writes DDL of functions former than that of tables. 
Actually, gpbackup tries to resolve dependencies, but this function doesn't depend on the table, it depends on a composite type of a _row_ of this table, which was created automatically when the table was created. This kind of types is not recognized by gpbackup and can't be created separately from a table, so gpbackup doesn't back it up. Also, pg_depend doesn't show that neither a table depends on this type, nor a type depends on a table it was created with, so gpbackup doesn't see any connections between the table and the function that uses this table. It can lead to a situation when a function may be in the queue to be recovered before the table it depends on.
The easiest solution is to sort all relations by oids before dependencies are resolved, because usually the bigger oid is, the later the relation was created, which means that objects with smaller oids shouldn't depends on the ones with bigger oids. However, it's now always true, that's why dependencies should be resolved after sorting by oids, which guarantees correct order of relations.