### PR TITLE
arenadata: modify build scripts

### DIFF
--- a/arenadata/run_gpbackup_tests.bash
+++ b/arenadata/run_gpbackup_tests.bash
@@ -9,11 +9,11 @@ make -C gpdb_src/contrib/dummy_seclabel/ install
 gpdb_src/concourse/scripts/setup_gpadmin_user.bash
 make_cluster
 
+wget https://golang.org/dl/go1.20.5.linux-amd64.tar.gz -O - | tar -C /opt -xz;
+
 su - gpadmin -c "
 source /usr/local/greenplum-db-devel/greenplum_path.sh;
 source ~/gpdb_src/gpAux/gpdemo/gpdemo-env.sh;
 gpconfig -c shared_preload_libraries -v dummy_seclabel;
 gpstop -ar;
-wget https://golang.org/dl/go1.17.6.linux-amd64.tar.gz;
-tar -C ~/ -xzf go1.17.6.linux-amd64.tar.gz;
-PATH=$PATH:~/go/bin GOPATH=~/go make depend build install test end_to_end -C go/src/github.com/greenplum-db/gpbackup/"
+PATH=$PATH:/opt/go/bin:~/go/bin GOPATH=~/go make depend build install test end_to_end -C /home/gpadmin/go/src/github.com/greenplum-db/gpbackup"


### PR DESCRIPTION
- go binary was bumped to 1.20.5
- directory to store go binaries was changed: instead of ~/go (GOPATH) directory /opt/go uses to untar go archive. It's done due to compilation errors (`unkeyed fields at composite literals`, here is a link to stackoverflow: https://stackoverflow.com/questions/54548441/composite-literal-uses-unkeyed-fields) occured at unit-test stage (restore tets), after merging with upstream code, like:

```bash
#> PATH=$PATH:~/go/bin GOPATH=~/go ginkgo restore
Failed to compile restore:
# github.com/greenplum-db/gpbackup/restore_test
./wrappers_test.go:168:54: github.com/greenplum-db/gpbackup/history.RestorePlanEntry struct literal uses unkeyed fields
./wrappers_test.go:194:54: github.com/greenplum-db/gpbackup/history.RestorePlanEntry struct literal uses unkeyed fields
```

 The error occurs at next (strange) condition: when go binary stores at GOPATH directory (untar was performed to GOPATH). Seems it's a golang issue (further research is needed)
