### PR TITLE
ADBDEV-4198: Exclude subpartitions for given root partition in leaf-partition-data mode

### DIFF
--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -56,7 +56,7 @@ func getExcludedRelationOidsList(connectionPool *dbconn.DBConn, quotedIncludeRel
 	UNION
 	SELECT r.parchildrelid as _oid
 	FROM pg_partition p join pg_partition_rule r on p.oid = r.paroid
-		join root_oids oids on p.parrelid = oids.a WHERE r.parchildrelid != 0
+		join root_oids oids on p.parrelid = oids._oid WHERE r.parchildrelid != 0
 	`, relList)
 	return dbconn.MustSelectStringSlice(connectionPool, query)
 }

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -44,9 +44,8 @@ func relationAndSchemaFilterClause() string {
 
 func getOidsFromRelationList(connectionPool *dbconn.DBConn, quotedIncludeRelations []string) []string {
 	relList := utils.SliceToQuotedString(quotedIncludeRelations)
-	// query broken
-	// the query is broken firstly, there are useless union
 
+	// is this solution correct for cases with include
 	query := fmt.Sprintf(`
 	WITH root_oids AS (
 		SELECT c.oid AS a

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/backup"
 	"github.com/greenplum-db/gpbackup/filepath"
+	"github.com/greenplum-db/gpbackup/history"
 	"github.com/greenplum-db/gpbackup/testutils"
 	"github.com/greenplum-db/gpbackup/toc"
 	"github.com/greenplum-db/gpbackup/utils"
@@ -2509,6 +2510,63 @@ LANGUAGE plpgsql NO SQL;`)
 					Fail(fmt.Sprintf("Expected printed timestamp %s to match timestamp %s in report file", stdoutEndTime, reportEndTime))
 				}
 			}
+		})
+	})
+	Describe("Exclude subpartitions for given root partition in leaf-partition-data mode", func() {
+		BeforeEach(func() {
+			testhelper.AssertQueryRuns(backupConn,
+				"CREATE SCHEMA testschema")
+			testhelper.AssertQueryRuns(backupConn,
+				`CREATE TABLE testschema.p3_sales (id int, a int, b int, region text)
+				WITH (appendoptimized=true)
+				DISTRIBUTED BY (id)
+				PARTITION BY RANGE (a)
+					SUBPARTITION BY RANGE (b)
+					SUBPARTITION TEMPLATE (
+						START (1) END (3) EVERY (1))
+						SUBPARTITION BY LIST (region)
+							SUBPARTITION TEMPLATE (
+							SUBPARTITION usa VALUES ('usa'),
+							SUBPARTITION europe VALUES ('europe'))
+				( START (1) END (3) EVERY (1))`)
+		})
+		AfterEach(func() {
+			testhelper.AssertQueryRuns(backupConn,
+				"DROP SCHEMA IF EXISTS testschema CASCADE")
+
+		})
+		It("1. --leaf-partition-data is set and --exclude-table is set for root partition", func() {
+			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data", "--include-schema", "testschema", "--exclude-table", "testschema.p3_sales")
+			defer assertArtifactsCleaned(restoreConn, timestamp)
+			historyDB, err := history.InitializeHistoryDatabase(historyFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			backupConfig, err := history.GetBackupConfig(timestamp, historyDB)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(backupConfig.LeafPartitionData).To(BeTrue())
+			Expect(backupConfig.RestorePlan).To(HaveLen(0))
+		})
+		It("2. --leaf-partition-data is set and --exclude-table is set for leaf partition", func() {
+			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data", "--include-schema", "testschema", "--exclude-table", "testschema.p3_sales_1_prt_1_2_prt_1_3_prt_usa")
+			defer assertArtifactsCleaned(restoreConn, timestamp)
+			historyDB, err := history.InitializeHistoryDatabase(historyFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			backupConfig, err := history.GetBackupConfig(timestamp, historyDB)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(backupConfig.LeafPartitionData).To(BeTrue())
+			Expect(backupConfig.RestorePlan).To(HaveLen(1))
+			Expect(backupConfig.RestorePlan[0].Timestamp).To(Equal(timestamp))
+			Expect(backupConfig.RestorePlan[0].TableFQNs).To(HaveLen(7))
+			Expect(backupConfig.RestorePlan[0].TableFQNs).ToNot(ContainElement(`testschema.p3_sales_1_prt_1_2_prt_1_3_prt_usa`))
+		})
+		It("3. --leaf-partition-data is not set and --exclude-table is set for root partition", func() {
+			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--include-schema", "testschema", "--exclude-table", "testschema.p3_sales")
+			defer assertArtifactsCleaned(restoreConn, timestamp)
+			historyDB, err := history.InitializeHistoryDatabase(historyFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			backupConfig, err := history.GetBackupConfig(timestamp, historyDB)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(backupConfig.LeafPartitionData).To(BeFalse())
+			Expect(backupConfig.RestorePlan).To(HaveLen(0))
 		})
 	})
 })

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/backup"
 	"github.com/greenplum-db/gpbackup/filepath"
-	"github.com/greenplum-db/gpbackup/history"
 	"github.com/greenplum-db/gpbackup/testutils"
 	"github.com/greenplum-db/gpbackup/toc"
 	"github.com/greenplum-db/gpbackup/utils"
@@ -2510,63 +2509,6 @@ LANGUAGE plpgsql NO SQL;`)
 					Fail(fmt.Sprintf("Expected printed timestamp %s to match timestamp %s in report file", stdoutEndTime, reportEndTime))
 				}
 			}
-		})
-	})
-	Describe("Exclude subpartitions for given root partition in leaf-partition-data mode", func() {
-		BeforeEach(func() {
-			testhelper.AssertQueryRuns(backupConn,
-				"CREATE SCHEMA testschema")
-			testhelper.AssertQueryRuns(backupConn,
-				`CREATE TABLE testschema.p3_sales (id int, a int, b int, region text)
-				WITH (appendoptimized=true)
-				DISTRIBUTED BY (id)
-				PARTITION BY RANGE (a)
-					SUBPARTITION BY RANGE (b)
-					SUBPARTITION TEMPLATE (
-						START (1) END (3) EVERY (1))
-						SUBPARTITION BY LIST (region)
-							SUBPARTITION TEMPLATE (
-							SUBPARTITION usa VALUES ('usa'),
-							SUBPARTITION europe VALUES ('europe'))
-				( START (1) END (3) EVERY (1))`)
-		})
-		AfterEach(func() {
-			testhelper.AssertQueryRuns(backupConn,
-				"DROP SCHEMA IF EXISTS testschema CASCADE")
-
-		})
-		It("1. --leaf-partition-data is set and --exclude-table is set for root partition", func() {
-			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data", "--include-schema", "testschema", "--exclude-table", "testschema.p3_sales")
-			defer assertArtifactsCleaned(restoreConn, timestamp)
-			historyDB, err := history.InitializeHistoryDatabase(historyFilePath)
-			Expect(err).ToNot(HaveOccurred())
-			backupConfig, err := history.GetBackupConfig(timestamp, historyDB)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(backupConfig.LeafPartitionData).To(BeTrue())
-			Expect(backupConfig.RestorePlan).To(HaveLen(0))
-		})
-		It("2. --leaf-partition-data is set and --exclude-table is set for leaf partition", func() {
-			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data", "--include-schema", "testschema", "--exclude-table", "testschema.p3_sales_1_prt_1_2_prt_1_3_prt_usa")
-			defer assertArtifactsCleaned(restoreConn, timestamp)
-			historyDB, err := history.InitializeHistoryDatabase(historyFilePath)
-			Expect(err).ToNot(HaveOccurred())
-			backupConfig, err := history.GetBackupConfig(timestamp, historyDB)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(backupConfig.LeafPartitionData).To(BeTrue())
-			Expect(backupConfig.RestorePlan).To(HaveLen(1))
-			Expect(backupConfig.RestorePlan[0].Timestamp).To(Equal(timestamp))
-			Expect(backupConfig.RestorePlan[0].TableFQNs).To(HaveLen(7))
-			Expect(backupConfig.RestorePlan[0].TableFQNs).ToNot(ContainElement(`testschema.p3_sales_1_prt_1_2_prt_1_3_prt_usa`))
-		})
-		It("3. --leaf-partition-data is not set and --exclude-table is set for root partition", func() {
-			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--include-schema", "testschema", "--exclude-table", "testschema.p3_sales")
-			defer assertArtifactsCleaned(restoreConn, timestamp)
-			historyDB, err := history.InitializeHistoryDatabase(historyFilePath)
-			Expect(err).ToNot(HaveOccurred())
-			backupConfig, err := history.GetBackupConfig(timestamp, historyDB)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(backupConfig.LeafPartitionData).To(BeFalse())
-			Expect(backupConfig.RestorePlan).To(HaveLen(0))
 		})
 	})
 })

--- a/end_to_end/filtered_test.go
+++ b/end_to_end/filtered_test.go
@@ -438,7 +438,7 @@ PARTITION BY LIST (gender)
 	Describe("Exclude subpartitions for given root partition in leaf-partition-data mode", func() {
 		It("runs gpbackup and gprestore with leaf-partition-data and exclude-table root partition backup flags", func() {
 			testhelper.AssertQueryRuns(backupConn,
-				`DROP SCHEMA IF EXISTS testschema1 CASCADE; CREATE SCHEMA testschema1`)
+				`CREATE SCHEMA testschema1`)
 			testhelper.AssertQueryRuns(backupConn,
 				`CREATE TABLE testschema1.p3_sales (id int, a int, b int, region text)
 				WITH (appendoptimized=true)
@@ -452,7 +452,7 @@ PARTITION BY LIST (gender)
 							SUBPARTITION usa VALUES ('usa'),
 							SUBPARTITION europe VALUES ('europe'))
 				( START (1) END (3) EVERY (1))`)
-			defer testhelper.AssertQueryRuns(backupConn, `DROP SCHEMA IF EXISTS testschema1 CASCADE`)
+			defer testhelper.AssertQueryRuns(backupConn, `DROP SCHEMA testschema1 CASCADE`)
 			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data", "--exclude-table", "testschema1.p3_sales")
 			gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb")
 			assertTablesNotRestored(restoreConn, []string{
@@ -476,7 +476,7 @@ PARTITION BY LIST (gender)
 		})
 		It("runs gpbackup and gprestore with leaf-partition-data and exclude-table leaf partition backup flags", func() {
 			testhelper.AssertQueryRuns(backupConn,
-				`DROP SCHEMA IF EXISTS testschema2 CASCADE; CREATE SCHEMA testschema2`)
+				`CREATE SCHEMA testschema2`)
 			testhelper.AssertQueryRuns(backupConn,
 				`CREATE TABLE testschema2.p3_sales (id int, a int, b int, region text)
 				WITH (appendoptimized=true)
@@ -501,7 +501,7 @@ PARTITION BY LIST (gender)
 					(1, 2, 2, 'usa'),
 					(1, 2, 2, 'europe')
 				`)
-			defer testhelper.AssertQueryRuns(backupConn, `DROP SCHEMA IF EXISTS testschema2 CASCADE`)
+			defer testhelper.AssertQueryRuns(backupConn, `DROP SCHEMA testschema2 CASCADE`)
 			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data", "--exclude-table", "testschema2.p3_sales_1_prt_1_2_prt_1_3_prt_usa")
 			gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb")
 			assertTablesRestored(restoreConn, []string{
@@ -542,7 +542,7 @@ PARTITION BY LIST (gender)
 		})
 		It("runs gpbackup and gprestore without leaf-partition-data and with exclude-table root partition backup flags", func() {
 			testhelper.AssertQueryRuns(backupConn,
-				`DROP SCHEMA IF EXISTS testschema3 CASCADE; CREATE SCHEMA testschema3`)
+				`CREATE SCHEMA testschema3`)
 			testhelper.AssertQueryRuns(backupConn,
 				`CREATE TABLE testschema3.p3_sales (id int, a int, b int, region text)
 				WITH (appendoptimized=true)
@@ -556,7 +556,7 @@ PARTITION BY LIST (gender)
 							SUBPARTITION usa VALUES ('usa'),
 							SUBPARTITION europe VALUES ('europe'))
 				( START (1) END (3) EVERY (1))`)
-			defer testhelper.AssertQueryRuns(backupConn, `DROP SCHEMA IF EXISTS testschema3 CASCADE`)
+			defer testhelper.AssertQueryRuns(backupConn, `DROP SCHEMA testschema3 CASCADE`)
 			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--exclude-table", "testschema3.p3_sales")
 			gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb")
 			assertTablesNotRestored(restoreConn, []string{

--- a/end_to_end/filtered_test.go
+++ b/end_to_end/filtered_test.go
@@ -438,9 +438,7 @@ PARTITION BY LIST (gender)
 	Describe("Exclude subpartitions for given root partition in leaf-partition-data mode", func() {
 		It("runs gpbackup and gprestore with leaf-partition-data and exclude-table root partition backup flags", func() {
 			testhelper.AssertQueryRuns(backupConn,
-				`CREATE SCHEMA testschema1`)
-			testhelper.AssertQueryRuns(backupConn,
-				`CREATE TABLE testschema1.p3_sales (id int, a int, b int, region text)
+				`CREATE TABLE public.p1_sales (id int, a int, b int, region text)
 				WITH (appendoptimized=true)
 				DISTRIBUTED BY (id)
 				PARTITION BY RANGE (a)
@@ -452,33 +450,31 @@ PARTITION BY LIST (gender)
 							SUBPARTITION usa VALUES ('usa'),
 							SUBPARTITION europe VALUES ('europe'))
 				( START (1) END (3) EVERY (1))`)
-			defer testhelper.AssertQueryRuns(backupConn, `DROP SCHEMA testschema1 CASCADE`)
-			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data", "--exclude-table", "testschema1.p3_sales")
+			defer testhelper.AssertQueryRuns(backupConn, `DROP TABLE public.p1_sales CASCADE`)
+			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data", "--exclude-table", "public.p1_sales")
+			defer assertArtifactsCleaned(restoreConn, timestamp)
 			gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb")
 			assertTablesNotRestored(restoreConn, []string{
-				"testschema1.p3_sales",
-				"testschema1.p3_sales_1_prt_1",
-				"testschema1.p3_sales_1_prt_1_2_prt_1",
-				"testschema1.p3_sales_1_prt_1_2_prt_1_3_prt_europe",
-				"testschema1.p3_sales_1_prt_1_2_prt_1_3_prt_usa",
-				"testschema1.p3_sales_1_prt_1_2_prt_2",
-				"testschema1.p3_sales_1_prt_1_2_prt_2_3_prt_europe",
-				"testschema1.p3_sales_1_prt_1_2_prt_2_3_prt_usa",
-				"testschema1.p3_sales_1_prt_2",
-				"testschema1.p3_sales_1_prt_2_2_prt_1",
-				"testschema1.p3_sales_1_prt_2_2_prt_1_3_prt_europe",
-				"testschema1.p3_sales_1_prt_2_2_prt_1_3_prt_usa",
-				"testschema1.p3_sales_1_prt_2_2_prt_2",
-				"testschema1.p3_sales_1_prt_2_2_prt_2_3_prt_europe",
-				"testschema1.p3_sales_1_prt_2_2_prt_2_3_prt_usa",
+				"public.p1_sales",
+				"public.p1_sales_1_prt_1",
+				"public.p1_sales_1_prt_1_2_prt_1",
+				"public.p1_sales_1_prt_1_2_prt_1_3_prt_europe",
+				"public.p1_sales_1_prt_1_2_prt_1_3_prt_usa",
+				"public.p1_sales_1_prt_1_2_prt_2",
+				"public.p1_sales_1_prt_1_2_prt_2_3_prt_europe",
+				"public.p1_sales_1_prt_1_2_prt_2_3_prt_usa",
+				"public.p1_sales_1_prt_2",
+				"public.p1_sales_1_prt_2_2_prt_1",
+				"public.p1_sales_1_prt_2_2_prt_1_3_prt_europe",
+				"public.p1_sales_1_prt_2_2_prt_1_3_prt_usa",
+				"public.p1_sales_1_prt_2_2_prt_2",
+				"public.p1_sales_1_prt_2_2_prt_2_3_prt_europe",
+				"public.p1_sales_1_prt_2_2_prt_2_3_prt_usa",
 			})
-			assertArtifactsCleaned(restoreConn, timestamp)
 		})
 		It("runs gpbackup and gprestore with leaf-partition-data and exclude-table leaf partition backup flags", func() {
 			testhelper.AssertQueryRuns(backupConn,
-				`CREATE SCHEMA testschema2`)
-			testhelper.AssertQueryRuns(backupConn,
-				`CREATE TABLE testschema2.p3_sales (id int, a int, b int, region text)
+				`CREATE TABLE public.p2_sales (id int, a int, b int, region text)
 				WITH (appendoptimized=true)
 				DISTRIBUTED BY (id)
 				PARTITION BY RANGE (a)
@@ -491,7 +487,7 @@ PARTITION BY LIST (gender)
 							SUBPARTITION europe VALUES ('europe'))
 				( START (1) END (3) EVERY (1))`)
 			testhelper.AssertQueryRuns(backupConn,
-				`INSERT INTO testschema2.p3_sales VALUES
+				`INSERT INTO public.p2_sales VALUES
 					(1, 1, 1, 'usa'),
 					(1, 1, 1, 'europe'),
 					(1, 1, 2, 'usa'),
@@ -501,50 +497,48 @@ PARTITION BY LIST (gender)
 					(1, 2, 2, 'usa'),
 					(1, 2, 2, 'europe')
 				`)
-			defer testhelper.AssertQueryRuns(backupConn, `DROP SCHEMA testschema2 CASCADE`)
-			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data", "--exclude-table", "testschema2.p3_sales_1_prt_1_2_prt_1_3_prt_usa")
+			defer testhelper.AssertQueryRuns(backupConn, `DROP TABLE public.p2_sales CASCADE`)
+			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data", "--exclude-table", "public.p2_sales_1_prt_1_2_prt_1_3_prt_usa")
+			defer assertArtifactsCleaned(restoreConn, timestamp)
 			gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb")
 			assertTablesRestored(restoreConn, []string{
-				"testschema2.p3_sales",
-				"testschema2.p3_sales_1_prt_1",
-				"testschema2.p3_sales_1_prt_1_2_prt_1",
-				"testschema2.p3_sales_1_prt_1_2_prt_1_3_prt_europe",
-				"testschema2.p3_sales_1_prt_1_2_prt_1_3_prt_usa",
-				"testschema2.p3_sales_1_prt_1_2_prt_2",
-				"testschema2.p3_sales_1_prt_1_2_prt_2_3_prt_europe",
-				"testschema2.p3_sales_1_prt_1_2_prt_2_3_prt_usa",
-				"testschema2.p3_sales_1_prt_2",
-				"testschema2.p3_sales_1_prt_2_2_prt_1",
-				"testschema2.p3_sales_1_prt_2_2_prt_1_3_prt_europe",
-				"testschema2.p3_sales_1_prt_2_2_prt_1_3_prt_usa",
-				"testschema2.p3_sales_1_prt_2_2_prt_2",
-				"testschema2.p3_sales_1_prt_2_2_prt_2_3_prt_europe",
-				"testschema2.p3_sales_1_prt_2_2_prt_2_3_prt_usa",
+				"public.p2_sales",
+				"public.p2_sales_1_prt_1",
+				"public.p2_sales_1_prt_1_2_prt_1",
+				"public.p2_sales_1_prt_1_2_prt_1_3_prt_europe",
+				"public.p2_sales_1_prt_1_2_prt_1_3_prt_usa",
+				"public.p2_sales_1_prt_1_2_prt_2",
+				"public.p2_sales_1_prt_1_2_prt_2_3_prt_europe",
+				"public.p2_sales_1_prt_1_2_prt_2_3_prt_usa",
+				"public.p2_sales_1_prt_2",
+				"public.p2_sales_1_prt_2_2_prt_1",
+				"public.p2_sales_1_prt_2_2_prt_1_3_prt_europe",
+				"public.p2_sales_1_prt_2_2_prt_1_3_prt_usa",
+				"public.p2_sales_1_prt_2_2_prt_2",
+				"public.p2_sales_1_prt_2_2_prt_2_3_prt_europe",
+				"public.p2_sales_1_prt_2_2_prt_2_3_prt_usa",
 			})
 			assertDataRestored(restoreConn, map[string]int{
-				"testschema2.p3_sales":                              7,
-				"testschema2.p3_sales_1_prt_1":                      3,
-				"testschema2.p3_sales_1_prt_1_2_prt_1":              1,
-				"testschema2.p3_sales_1_prt_1_2_prt_1_3_prt_europe": 1,
-				"testschema2.p3_sales_1_prt_1_2_prt_1_3_prt_usa":    0,
-				"testschema2.p3_sales_1_prt_1_2_prt_2":              2,
-				"testschema2.p3_sales_1_prt_1_2_prt_2_3_prt_europe": 1,
-				"testschema2.p3_sales_1_prt_1_2_prt_2_3_prt_usa":    1,
-				"testschema2.p3_sales_1_prt_2":                      4,
-				"testschema2.p3_sales_1_prt_2_2_prt_1":              2,
-				"testschema2.p3_sales_1_prt_2_2_prt_1_3_prt_europe": 1,
-				"testschema2.p3_sales_1_prt_2_2_prt_1_3_prt_usa":    1,
-				"testschema2.p3_sales_1_prt_2_2_prt_2":              2,
-				"testschema2.p3_sales_1_prt_2_2_prt_2_3_prt_europe": 1,
-				"testschema2.p3_sales_1_prt_2_2_prt_2_3_prt_usa":    1,
+				"public.p2_sales":                              7,
+				"public.p2_sales_1_prt_1":                      3,
+				"public.p2_sales_1_prt_1_2_prt_1":              1,
+				"public.p2_sales_1_prt_1_2_prt_1_3_prt_europe": 1,
+				"public.p2_sales_1_prt_1_2_prt_1_3_prt_usa":    0,
+				"public.p2_sales_1_prt_1_2_prt_2":              2,
+				"public.p2_sales_1_prt_1_2_prt_2_3_prt_europe": 1,
+				"public.p2_sales_1_prt_1_2_prt_2_3_prt_usa":    1,
+				"public.p2_sales_1_prt_2":                      4,
+				"public.p2_sales_1_prt_2_2_prt_1":              2,
+				"public.p2_sales_1_prt_2_2_prt_1_3_prt_europe": 1,
+				"public.p2_sales_1_prt_2_2_prt_1_3_prt_usa":    1,
+				"public.p2_sales_1_prt_2_2_prt_2":              2,
+				"public.p2_sales_1_prt_2_2_prt_2_3_prt_europe": 1,
+				"public.p2_sales_1_prt_2_2_prt_2_3_prt_usa":    1,
 			})
-			assertArtifactsCleaned(restoreConn, timestamp)
 		})
 		It("runs gpbackup and gprestore without leaf-partition-data and with exclude-table root partition backup flags", func() {
 			testhelper.AssertQueryRuns(backupConn,
-				`CREATE SCHEMA testschema3`)
-			testhelper.AssertQueryRuns(backupConn,
-				`CREATE TABLE testschema3.p3_sales (id int, a int, b int, region text)
+				`CREATE TABLE public.p3_sales (id int, a int, b int, region text)
 				WITH (appendoptimized=true)
 				DISTRIBUTED BY (id)
 				PARTITION BY RANGE (a)
@@ -556,27 +550,27 @@ PARTITION BY LIST (gender)
 							SUBPARTITION usa VALUES ('usa'),
 							SUBPARTITION europe VALUES ('europe'))
 				( START (1) END (3) EVERY (1))`)
-			defer testhelper.AssertQueryRuns(backupConn, `DROP SCHEMA testschema3 CASCADE`)
-			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--exclude-table", "testschema3.p3_sales")
+			defer testhelper.AssertQueryRuns(backupConn, `DROP TABLE public.p3_sales CASCADE`)
+			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--exclude-table", "public.p3_sales")
+			defer assertArtifactsCleaned(restoreConn, timestamp)
 			gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb")
 			assertTablesNotRestored(restoreConn, []string{
-				"testschema3.p3_sales",
-				"testschema3.p3_sales_1_prt_1",
-				"testschema3.p3_sales_1_prt_1_2_prt_1",
-				"testschema3.p3_sales_1_prt_1_2_prt_1_3_prt_europe",
-				"testschema3.p3_sales_1_prt_1_2_prt_1_3_prt_usa",
-				"testschema3.p3_sales_1_prt_1_2_prt_2",
-				"testschema3.p3_sales_1_prt_1_2_prt_2_3_prt_europe",
-				"testschema3.p3_sales_1_prt_1_2_prt_2_3_prt_usa",
-				"testschema3.p3_sales_1_prt_2",
-				"testschema3.p3_sales_1_prt_2_2_prt_1",
-				"testschema3.p3_sales_1_prt_2_2_prt_1_3_prt_europe",
-				"testschema3.p3_sales_1_prt_2_2_prt_1_3_prt_usa",
-				"testschema3.p3_sales_1_prt_2_2_prt_2",
-				"testschema3.p3_sales_1_prt_2_2_prt_2_3_prt_europe",
-				"testschema3.p3_sales_1_prt_2_2_prt_2_3_prt_usa",
+				"public.p3_sales",
+				"public.p3_sales_1_prt_1",
+				"public.p3_sales_1_prt_1_2_prt_1",
+				"public.p3_sales_1_prt_1_2_prt_1_3_prt_europe",
+				"public.p3_sales_1_prt_1_2_prt_1_3_prt_usa",
+				"public.p3_sales_1_prt_1_2_prt_2",
+				"public.p3_sales_1_prt_1_2_prt_2_3_prt_europe",
+				"public.p3_sales_1_prt_1_2_prt_2_3_prt_usa",
+				"public.p3_sales_1_prt_2",
+				"public.p3_sales_1_prt_2_2_prt_1",
+				"public.p3_sales_1_prt_2_2_prt_1_3_prt_europe",
+				"public.p3_sales_1_prt_2_2_prt_1_3_prt_usa",
+				"public.p3_sales_1_prt_2_2_prt_2",
+				"public.p3_sales_1_prt_2_2_prt_2_3_prt_europe",
+				"public.p3_sales_1_prt_2_2_prt_2_3_prt_usa",
 			})
-			assertArtifactsCleaned(restoreConn, timestamp)
 		})
 	})
 })

--- a/end_to_end/filtered_test.go
+++ b/end_to_end/filtered_test.go
@@ -452,6 +452,7 @@ PARTITION BY LIST (gender)
 							SUBPARTITION usa VALUES ('usa'),
 							SUBPARTITION europe VALUES ('europe'))
 				( START (1) END (3) EVERY (1))`)
+			defer testhelper.AssertQueryRuns(backupConn, `DROP SCHEMA IF EXISTS testschema1 CASCADE`)
 			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data", "--exclude-table", "testschema1.p3_sales")
 			gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb")
 			assertTablesNotRestored(restoreConn, []string{
@@ -472,8 +473,6 @@ PARTITION BY LIST (gender)
 				"testschema1.p3_sales_1_prt_2_2_prt_2_3_prt_usa",
 			})
 			assertArtifactsCleaned(restoreConn, timestamp)
-			testhelper.AssertQueryRuns(backupConn,
-				`DROP SCHEMA IF EXISTS testschema1 CASCADE`)
 		})
 		It("runs gpbackup and gprestore with leaf-partition-data and exclude-table leaf partition backup flags", func() {
 			testhelper.AssertQueryRuns(backupConn,
@@ -502,6 +501,7 @@ PARTITION BY LIST (gender)
 					(1, 2, 2, 'usa'),
 					(1, 2, 2, 'europe')
 				`)
+			defer testhelper.AssertQueryRuns(backupConn, `DROP SCHEMA IF EXISTS testschema2 CASCADE`)
 			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data", "--exclude-table", "testschema2.p3_sales_1_prt_1_2_prt_1_3_prt_usa")
 			gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb")
 			assertTablesRestored(restoreConn, []string{
@@ -539,8 +539,6 @@ PARTITION BY LIST (gender)
 				"testschema2.p3_sales_1_prt_2_2_prt_2_3_prt_usa":    1,
 			})
 			assertArtifactsCleaned(restoreConn, timestamp)
-			testhelper.AssertQueryRuns(backupConn,
-				`DROP SCHEMA IF EXISTS testschema2 CASCADE`)
 		})
 		It("runs gpbackup and gprestore without leaf-partition-data and with exclude-table root partition backup flags", func() {
 			testhelper.AssertQueryRuns(backupConn,
@@ -558,6 +556,7 @@ PARTITION BY LIST (gender)
 							SUBPARTITION usa VALUES ('usa'),
 							SUBPARTITION europe VALUES ('europe'))
 				( START (1) END (3) EVERY (1))`)
+			defer testhelper.AssertQueryRuns(backupConn, `DROP SCHEMA IF EXISTS testschema3 CASCADE`)
 			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--exclude-table", "testschema3.p3_sales")
 			gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb")
 			assertTablesNotRestored(restoreConn, []string{
@@ -578,8 +577,6 @@ PARTITION BY LIST (gender)
 				"testschema3.p3_sales_1_prt_2_2_prt_2_3_prt_usa",
 			})
 			assertArtifactsCleaned(restoreConn, timestamp)
-			testhelper.AssertQueryRuns(backupConn,
-				`DROP SCHEMA IF EXISTS testschema3 CASCADE`)
 		})
 	})
 })


### PR DESCRIPTION
Exclude subpartitions for given root partition in leaf-partition-data mode

gpbackup with the --leaf-partition-data and --exclude <root_partition> options
adds leaf partitions to the recovery plan, but the root partition is not
included in the schema creation script and gprestore fails with an error.

The solution is to exclude all leaf partitions for a given root partition
in leaf-partition-data mode.

The first test checks that if root partition exclusion and the
leaf-partition-data option are specified, then leaf partitions
should not be included in the restore.
The second test checks that if leaf partition exclusion and the
leaf-partition-data option are specified, then the patch does not
change the behavior: only this leaf partition is excluded from the backup.
The third test checks that if only a root partition exclusion
is specified, then the patch does not change the behavior:
the table does not include into the backup.