### PR TITLE
ADBDEV-4377: Fix backup statistics for leaf partitions

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -124,7 +124,7 @@ func DoBackup() {
 	}
 
 	gplog.Info("Gathering table state information")
-	metadataTables, dataTables := RetrieveAndProcessTables()
+	metadataTables, dataTables, allTables := RetrieveAndProcessTables()
 	dataTables, numExtOrForeignTables := GetBackupDataSet(dataTables)
 	if len(dataTables) == 0 && !backupReport.MetadataOnly {
 		gplog.Warn("No tables in backup set contain data. Performing metadata-only backup instead.")
@@ -191,7 +191,7 @@ func DoBackup() {
 
 	printDataBackupWarnings(numExtOrForeignTables)
 	if MustGetFlagBool(options.WITH_STATS) {
-		backupStatistics(metadataTables)
+		backupStatistics(allTables)
 	}
 
 	globalTOC.WriteToFileAndMakeReadOnly(globalFPInfo.GetTOCFilePath())

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -204,7 +204,7 @@ func createBackupDirectoriesOnAllHosts() {
  * Metadata retrieval wrapper functions
  */
 
-func RetrieveAndProcessTables() ([]Table, []Table) {
+func RetrieveAndProcessTables() ([]Table, []Table, []Table) {
 	quotedIncludeRelations, err := options.QuoteTableNames(connectionPool, MustGetFlagStringArray(options.INCLUDE_RELATION))
 	gplog.FatalOnError(err)
 
@@ -215,12 +215,12 @@ func RetrieveAndProcessTables() ([]Table, []Table) {
 		tableRelations = append(tableRelations, GetForeignTableRelations(connectionPool)...)
 	}
 
-	tables := ConstructDefinitionsForTables(connectionPool, tableRelations)
+	allTables := ConstructDefinitionsForTables(connectionPool, tableRelations)
 
-	metadataTables, dataTables := SplitTablesByPartitionType(tables, quotedIncludeRelations)
+	metadataTables, dataTables := SplitTablesByPartitionType(allTables, quotedIncludeRelations)
 	objectCounts["Tables"] = len(metadataTables)
 
-	return metadataTables, dataTables
+	return metadataTables, dataTables, allTables
 }
 
 func retrieveFunctions(sortables *[]Sortable, metadataMap MetadataMap) ([]Function, map[uint32]FunctionInfo) {

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1485,13 +1485,6 @@ var _ = Describe("backup and restore end to end tests", func() {
 			skipIfOldBackupVersionBefore("1.18.0")
 
 			testhelper.AssertQueryRuns(backupConn, `
-				CREATE TABLE et (
-					id character varying(13),
-					flg smallint,
-					dttm timestamp without time zone,
-					src character varying(80)
-				) WITH (appendonly='true', orientation='row', compresstype=zstd, compresslevel='3') DISTRIBUTED BY (id);
-
 				CREATE TABLE pt (
 					id character varying(13),
 					flg smallint,
@@ -1502,19 +1495,16 @@ var _ = Describe("backup and restore end to end tests", func() {
 				);
 
 				INSERT INTO pt(id, flg, dttm, src) VALUES (1, 1, now(), 'val');
-				INSERT INTO et(id, flg, dttm, src) VALUES (2, 2, now(), 'val');
 
 				ANALYZE pt;
-				ANALYZE et;
 				ANALYZE ROOTPARTITION pt;
-
-				ALTER TABLE pt EXCHANGE PARTITION src_mdm WITH TABLE et;
 			`)
 
 			defer testhelper.AssertQueryRuns(backupConn,
-				`DROP TABLE et CASCADE; DROP TABLE pt CASCADE;`)
+				`DROP TABLE pt CASCADE;`)
 			timestamp := gpbackup(gpbackupPath, backupHelperPath,
 				"--with-stats",
+				"--leaf-partition-data",
 				"--backup-dir", backupDir)
 			files, err := path.Glob(path.Join(backupDir, "*-1/backups/*",
 				timestamp, "*statistics.sql"))
@@ -1532,7 +1522,7 @@ var _ = Describe("backup and restore end to end tests", func() {
 			assertPGClassStatsRestored(backupConn, restoreConn, publicSchemaTupleCounts)
 			assertPGClassStatsRestored(backupConn, restoreConn, schema2TupleCounts)
 
-			statsQuery := fmt.Sprintf(`SELECT count(*) AS string FROM pg_statistic st left join pg_class cl on st.starelid = cl.oid left join pg_namespace nm on cl.relnamespace = nm.oid where cl.relname != 'pt_1_prt_src_mdm' AND %s;`, backup.SchemaFilterClause("nm"))
+			statsQuery := fmt.Sprintf(`SELECT count(*) AS string FROM pg_statistic st left join pg_class cl on st.starelid = cl.oid left join pg_namespace nm on cl.relnamespace = nm.oid where %s;`, backup.SchemaFilterClause("nm"))
 			backupStatisticCount := dbconn.MustSelectString(backupConn, statsQuery)
 			restoredStatisticsCount := dbconn.MustSelectString(restoreConn, statsQuery)
 

--- a/integration/wrappers_test.go
+++ b/integration/wrappers_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Wrappers Integration", func() {
 			connectionPool.MustBegin(0)
 			defer connectionPool.MustCommit(0)
 
-			_, dataTables := backup.RetrieveAndProcessTables()
+			_, dataTables, _ := backup.RetrieveAndProcessTables()
 			Expect(len(dataTables)).To(Equal(2))
 			Expect(dataTables[0].Name).To(Equal("foo"))
 			Expect(dataTables[1].Name).To(Equal(`"BAR"`))
@@ -59,7 +59,7 @@ var _ = Describe("Wrappers Integration", func() {
 			rootCmd := &cobra.Command{}
 			backup.DoInit(rootCmd) // initialize the ObjectCount
 
-			_, dataTables := backup.RetrieveAndProcessTables()
+			_, dataTables, _ := backup.RetrieveAndProcessTables()
 			Expect(len(dataTables)).To(Equal(3))
 			Expect(dataTables[0].Name).To(Equal("thousands"))
 			Expect(dataTables[1].Name).To(Equal("ten"))
@@ -72,7 +72,7 @@ var _ = Describe("Wrappers Integration", func() {
 			backup.DoInit(rootCmd) // initialize the ObjectCount
 			rootCmd.Execute()
 
-			_, dataTables := backup.RetrieveAndProcessTables()
+			_, dataTables, _ := backup.RetrieveAndProcessTables()
 			Expect(len(dataTables)).To(Equal(2))
 			Expect(dataTables[0].Name).To(Equal("ten"))
 			Expect(dataTables[1].Name).To(Equal("empty"))
@@ -84,7 +84,7 @@ var _ = Describe("Wrappers Integration", func() {
 			backup.DoInit(rootCmd) // initialize the ObjectCount
 			rootCmd.Execute()
 
-			_, dataTables := backup.RetrieveAndProcessTables()
+			_, dataTables, _ := backup.RetrieveAndProcessTables()
 			Expect(len(dataTables)).To(Equal(2))
 			Expect(dataTables[0].Name).To(Equal("ten"))
 			Expect(dataTables[1].Name).To(Equal("empty"))
@@ -115,7 +115,7 @@ var _ = Describe("Wrappers Integration", func() {
 			backup.DoInit(rootCmd) // initialize the ObjectCount
 			rootCmd.Execute()
 
-			_, dataTables := backup.RetrieveAndProcessTables()
+			_, dataTables, _ := backup.RetrieveAndProcessTables()
 			Expect(len(dataTables)).To(Equal(2))
 			Expect(dataTables[0].Name).To(Equal("thousands"))
 			Expect(dataTables[1].Name).To(Equal("empty"))
@@ -127,7 +127,7 @@ var _ = Describe("Wrappers Integration", func() {
 			backup.DoInit(rootCmd) // initialize the ObjectCount
 			rootCmd.Execute()
 
-			_, dataTables := backup.RetrieveAndProcessTables()
+			_, dataTables, _ := backup.RetrieveAndProcessTables()
 			Expect(len(dataTables)).To(Equal(2))
 			Expect(dataTables[0].Name).To(Equal("thousands"))
 			Expect(dataTables[1].Name).To(Equal("empty"))
@@ -164,7 +164,7 @@ var _ = Describe("Wrappers Integration", func() {
 			err := opts.ExpandIncludesForPartitions(connectionPool, rootCmd.Flags())
 			Expect(err).ShouldNot(HaveOccurred())
 
-			_, dataTables := backup.RetrieveAndProcessTables()
+			_, dataTables, _ := backup.RetrieveAndProcessTables()
 			Expect(len(dataTables)).To(Equal(2))
 			Expect(dataTables[0].Name).To(Equal("partition_table"))
 			Expect(dataTables[1].Name).To(Equal("ten"))
@@ -180,7 +180,7 @@ var _ = Describe("Wrappers Integration", func() {
 			err := opts.ExpandIncludesForPartitions(connectionPool, rootCmd.Flags())
 			Expect(err).ShouldNot(HaveOccurred())
 
-			_, dataTables := backup.RetrieveAndProcessTables()
+			_, dataTables, _ := backup.RetrieveAndProcessTables()
 
 			Expect(len(dataTables)).To(Equal(3))
 			Expect(dataTables[0].Name).To(Equal("partition_table_1_prt_girls"))
@@ -211,7 +211,7 @@ var _ = Describe("Wrappers Integration", func() {
 			rootCmd := &cobra.Command{}
 			backup.DoInit(rootCmd) // initialize the ObjectCount
 
-			_, dataTables := backup.RetrieveAndProcessTables()
+			_, dataTables, _ := backup.RetrieveAndProcessTables()
 			Expect(len(dataTables)).To(Equal(3))
 
 			Expect(dataTables[0].Name).To(Equal("thousands"))
@@ -230,7 +230,7 @@ var _ = Describe("Wrappers Integration", func() {
 			rootCmd := &cobra.Command{}
 			backup.DoInit(rootCmd) // initialize the ObjectCount
 
-			_, dataTables := backup.RetrieveAndProcessTables()
+			_, dataTables, _ := backup.RetrieveAndProcessTables()
 			Expect(len(dataTables)).To(Equal(3))
 
 			Expect(dataTables[0].Name).To(Equal("thousands"))


### PR DESCRIPTION
Fix backup statistics for leaf partitions

gpbackup does not backup statistics for leaf partitions with leaf-partition-data option

This patch solves the problem by backuping statistics for all specified
tables, including leaf partitions, and not just root partitions.

The test for this patch is based on the test for the 85384fadf774560b87df4d30792644b87069583e.
And, as stated in that patch, it removes the unnecessary
condition when comparing the number of statistics.