### PR TITLE
ADBDEV-4584: Implement extension dependency for gpbackup

### DIFF
--- a/end_to_end/resources/Makefile
+++ b/end_to_end/resources/Makefile
@@ -1,0 +1,9 @@
+MODULE = test_extensions
+
+EXTENSION = test_ext1 test_ext2 test_ext3 test_ext4 test_ext5
+DATA = test_ext1--1.0.sql test_ext2--1.0.sql test_ext3--1.0.sql \
+       test_ext4--1.0.sql test_ext5--1.0.sql
+
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)

--- a/end_to_end/resources/test_ext1--1.0.sql
+++ b/end_to_end/resources/test_ext1--1.0.sql
@@ -1,0 +1,3 @@
+/* src/test/modules/test_extensions/test_ext1--1.0.sql */
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_ext1" to load this file. \quit

--- a/end_to_end/resources/test_ext1.control
+++ b/end_to_end/resources/test_ext1.control
@@ -1,0 +1,5 @@
+comment = 'Test extension 1'
+default_version = '1.0'
+schema = 'test_ext1'
+relocatable = false
+requires = 'test_ext2,test_ext4'

--- a/end_to_end/resources/test_ext1.control
+++ b/end_to_end/resources/test_ext1.control
@@ -1,4 +1,4 @@
 comment = 'Test extension 1'
 default_version = '1.0'
-relocatable = false
+relocatable = true
 requires = 'test_ext2,test_ext4'

--- a/end_to_end/resources/test_ext1.control
+++ b/end_to_end/resources/test_ext1.control
@@ -1,5 +1,4 @@
 comment = 'Test extension 1'
 default_version = '1.0'
-schema = 'test_ext1'
 relocatable = false
 requires = 'test_ext2,test_ext4'

--- a/end_to_end/resources/test_ext2--1.0.sql
+++ b/end_to_end/resources/test_ext2--1.0.sql
@@ -1,0 +1,3 @@
+/* src/test/modules/test_extensions/test_ext2--1.0.sql */
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_ext2" to load this file. \quit

--- a/end_to_end/resources/test_ext2.control
+++ b/end_to_end/resources/test_ext2.control
@@ -1,0 +1,4 @@
+comment = 'Test extension 2'
+default_version = '1.0'
+relocatable = true
+requires = 'test_ext3,test_ext5'

--- a/end_to_end/resources/test_ext3--1.0.sql
+++ b/end_to_end/resources/test_ext3--1.0.sql
@@ -1,0 +1,9 @@
+/* src/test/modules/test_extensions/test_ext3--1.0.sql */
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_ext3" to load this file. \quit
+
+CREATE TABLE test_ext3_table (col_old INT);
+
+ALTER TABLE test_ext3_table RENAME col_old TO col_new;
+
+UPDATE test_ext3_table SET col_new = 0;

--- a/end_to_end/resources/test_ext3--1.0.sql
+++ b/end_to_end/resources/test_ext3--1.0.sql
@@ -1,9 +1,3 @@
 /* src/test/modules/test_extensions/test_ext3--1.0.sql */
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION test_ext3" to load this file. \quit
-
-CREATE TABLE test_ext3_table (col_old INT);
-
-ALTER TABLE test_ext3_table RENAME col_old TO col_new;
-
-UPDATE test_ext3_table SET col_new = 0;

--- a/end_to_end/resources/test_ext3.control
+++ b/end_to_end/resources/test_ext3.control
@@ -1,0 +1,3 @@
+comment = 'Test extension 3'
+default_version = '1.0'
+relocatable = true

--- a/end_to_end/resources/test_ext4--1.0.sql
+++ b/end_to_end/resources/test_ext4--1.0.sql
@@ -1,0 +1,3 @@
+/* src/test/modules/test_extensions/test_ext4--1.0.sql */
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_ext4" to load this file. \quit

--- a/end_to_end/resources/test_ext4.control
+++ b/end_to_end/resources/test_ext4.control
@@ -1,0 +1,4 @@
+comment = 'Test extension 4'
+default_version = '1.0'
+relocatable = true
+requires = 'test_ext5'

--- a/end_to_end/resources/test_ext5--1.0.sql
+++ b/end_to_end/resources/test_ext5--1.0.sql
@@ -1,0 +1,3 @@
+/* src/test/modules/test_extensions/test_ext5--1.0.sql */
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_ext5" to load this file. \quit

--- a/end_to_end/resources/test_ext5.control
+++ b/end_to_end/resources/test_ext5.control
@@ -1,0 +1,3 @@
+comment = 'Test extension 5'
+default_version = '1.0'
+relocatable = true


### PR DESCRIPTION
Implement extension dependency for gpbackup

gpbackup does not take into account extension dependencies and places commands to create extensions in a random order. This can lead to restoring errors if an extension is created that depends on another that has not yet been created.

This patch adds recursive sorting of extensions by dependencies. For 5X, simple sorting by OID is used, because there is no recursion support.
