### PR TITLE
ADBDEV-4584: Implement extension dependency for gpbackup

### DIFF
--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -831,13 +831,37 @@ func (e Extension) FQN() string {
 func GetExtensions(connectionPool *dbconn.DBConn) []Extension {
 	results := make([]Extension, 0)
 
-	query := fmt.Sprintf(`
-	SELECT e.oid,
-		quote_ident(extname) AS name,
-		quote_ident(n.nspname) AS schema
-	FROM pg_extension e
-		JOIN pg_namespace n ON e.extnamespace = n.oid
-	WHERE e.oid >= %d`, FIRST_NORMAL_OBJECT_ID)
+	query := ""
+	if connectionPool.Version.Before("6") {
+		query = fmt.Sprintf(`
+		SELECT e.oid,
+			quote_ident(extname) AS name,
+			quote_ident(n.nspname) AS schema
+		FROM pg_extension e
+			JOIN pg_namespace n ON e.extnamespace = n.oid
+		WHERE e.oid >= %d
+		ORDER BY 1`, FIRST_NORMAL_OBJECT_ID)
+	} else {
+		query = fmt.Sprintf(`
+		WITH recursive cte AS (
+			SELECT e.oid, 1 AS level FROM pg_catalog.pg_extension AS e
+				LEFT JOIN pg_catalog.pg_depend ON objid = oid
+					AND classid = 'pg_catalog.pg_extension'::pg_catalog.regclass
+					AND refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass
+				WHERE objid IS NULL
+			UNION ALL
+			SELECT objid AS oid, level + 1 AS level FROM cte
+				LEFT JOIN pg_catalog.pg_depend ON refobjid = oid
+					WHERE classid = 'pg_catalog.pg_extension'::pg_catalog.regclass
+						AND refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass
+		) SELECT e.oid,
+				quote_ident(extname) AS name,
+				quote_ident(n.nspname) AS schema
+		FROM cte
+			JOIN pg_catalog.pg_extension AS e ON e.oid = cte.oid
+			JOIN pg_catalog.pg_namespace AS n ON e.extnamespace = n.oid
+		WHERE e.oid >= %d ORDER BY level`, FIRST_NORMAL_OBJECT_ID)
+	}
 	err := connectionPool.Select(&results, query)
 	gplog.FatalOnError(err)
 	return results

--- a/end_to_end/resources/Makefile
+++ b/end_to_end/resources/Makefile
@@ -1,0 +1,9 @@
+MODULE = test_extensions
+
+EXTENSION = test_ext1 test_ext2 test_ext3 test_ext4 test_ext5
+DATA = test_ext1--1.0.sql test_ext2--1.0.sql test_ext3--1.0.sql \
+       test_ext4--1.0.sql test_ext5--1.0.sql
+
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)

--- a/end_to_end/resources/test_ext1--1.0.sql
+++ b/end_to_end/resources/test_ext1--1.0.sql
@@ -1,0 +1,3 @@
+/* src/test/modules/test_extensions/test_ext1--1.0.sql */
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_ext1" to load this file. \quit

--- a/end_to_end/resources/test_ext1.control
+++ b/end_to_end/resources/test_ext1.control
@@ -1,0 +1,4 @@
+comment = 'Test extension 1'
+default_version = '1.0'
+relocatable = true
+requires = 'test_ext2,test_ext4'

--- a/end_to_end/resources/test_ext2--1.0.sql
+++ b/end_to_end/resources/test_ext2--1.0.sql
@@ -1,0 +1,3 @@
+/* src/test/modules/test_extensions/test_ext2--1.0.sql */
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_ext2" to load this file. \quit

--- a/end_to_end/resources/test_ext2.control
+++ b/end_to_end/resources/test_ext2.control
@@ -1,0 +1,4 @@
+comment = 'Test extension 2'
+default_version = '1.0'
+relocatable = true
+requires = 'test_ext3,test_ext5'

--- a/end_to_end/resources/test_ext3--1.0.sql
+++ b/end_to_end/resources/test_ext3--1.0.sql
@@ -1,0 +1,3 @@
+/* src/test/modules/test_extensions/test_ext3--1.0.sql */
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_ext3" to load this file. \quit

--- a/end_to_end/resources/test_ext3.control
+++ b/end_to_end/resources/test_ext3.control
@@ -1,0 +1,3 @@
+comment = 'Test extension 3'
+default_version = '1.0'
+relocatable = true

--- a/end_to_end/resources/test_ext4--1.0.sql
+++ b/end_to_end/resources/test_ext4--1.0.sql
@@ -1,0 +1,3 @@
+/* src/test/modules/test_extensions/test_ext4--1.0.sql */
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_ext4" to load this file. \quit

--- a/end_to_end/resources/test_ext4.control
+++ b/end_to_end/resources/test_ext4.control
@@ -1,0 +1,4 @@
+comment = 'Test extension 4'
+default_version = '1.0'
+relocatable = true
+requires = 'test_ext5'

--- a/end_to_end/resources/test_ext5--1.0.sql
+++ b/end_to_end/resources/test_ext5--1.0.sql
@@ -1,0 +1,3 @@
+/* src/test/modules/test_extensions/test_ext5--1.0.sql */
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_ext5" to load this file. \quit

--- a/end_to_end/resources/test_ext5.control
+++ b/end_to_end/resources/test_ext5.control
@@ -1,0 +1,3 @@
+comment = 'Test extension 5'
+default_version = '1.0'
+relocatable = true


### PR DESCRIPTION
Implement extension dependency for gpbackup

gpbackup does not take into account extension dependencies and
places commands to create extensions in a random order.
This can lead to restoring errors if an extension is created that
depends on another that has not yet been created.

This patch adds recursive sorting of extensions by dependencies.
For 5X, simple sorting by OID is used, because there is no recursion support.