### PR TITLE
ADBDEV-4533: gpbackup does not use shared snapshot for first table in worker processes

### DIFF
--- a/backup/data.go
+++ b/backup/data.go
@@ -177,6 +177,12 @@ func BackupDataForAllTables(tables []Table) []map[uint32]int64 {
 				}
 			}()
 			defer workerPool.Done()
+			// Close opened transaction to open new transaction with shared snapshot below.
+			if backupSnapshot != "" && connectionPool.Tx[whichConn] != nil {
+				if err := connectionPool.Commit(whichConn); err != nil {
+					gplog.Warn("Worker %d: %s", whichConn, err)
+				}
+			}
 			/* If the --leaf-partition-data flag is not set, the parent and all leaf
 			 * partition data are treated as a single table and will be assigned to a single worker.
 			 * Large partition hierarchies result in a large number of locks being held until the


### PR DESCRIPTION
gpbackup does not use shared snapshot for first table in worker processes

gpbackup:

1) [creates](https://github.com/arenadata/gpbackup/blob/7d7f7d565ae81c2fe2fe34e59820ce3b84bde081/backup/wrappers.go#L62) a connection pool
2) [opens](https://github.com/arenadata/gpbackup/blob/7d7f7d565ae81c2fe2fe34e59820ce3b84bde081/backup/wrappers.go#L70) transactions for each connection
3) [takes and exports](https://github.com/arenadata/gpbackup/blob/7d7f7d565ae81c2fe2fe34e59820ce3b84bde081/backup/wrappers.go#L72) a shared snapshot of the first connection
4) [spawns](https://github.com/arenadata/gpbackup/blob/7d7f7d565ae81c2fe2fe34e59820ce3b84bde081/backup/data.go#L173) worker processes for all connections (except the first one),
   which perform the following actions:
    a) if the transaction is not yet open, then it is opened and
       the shared snapshot from step 3 is [imported](https://github.com/arenadata/gpbackup/blob/7d7f7d565ae81c2fe2fe34e59820ce3b84bde081/backup/data.go#L191) into it
    b) the table is copied using the COPY command
    c) if there is a shared snapshot, then the transaction is [closed](https://github.com/arenadata/gpbackup/blob/7d7f7d565ae81c2fe2fe34e59820ce3b84bde081/backup/data.go#L246)
    d) go to step 4.a

As a result, the first time step 4.a is skipped when copying the first
table in the worker process, because the transaction was opened in step 2.

The solution is to close the open transaction (after step 4 and before step
4.a) to open a new transaction with the shared snapshot below (at step 4.a).

A check has been added to the tests to ensure that the first table is also
processed in the shared snapshot.