### PR TITLE
ADBDEV-4597: Run gpbackup unit-tests on github actions

### DIFF
--- a/.github/workflows/build_and_unit_test.yml
+++ b/.github/workflows/build_and_unit_test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.19
 
     - name: Set Environment
       run: |

--- a/arenadata/run_gpbackup_tests.bash
+++ b/arenadata/run_gpbackup_tests.bash
@@ -16,4 +16,4 @@ source /usr/local/greenplum-db-devel/greenplum_path.sh;
 source ~/gpdb_src/gpAux/gpdemo/gpdemo-env.sh;
 gpconfig -c shared_preload_libraries -v dummy_seclabel;
 gpstop -ar;
-PATH=$PATH:/opt/go/bin:~/go/bin GOPATH=~/go make depend build install test end_to_end -C /home/gpadmin/go/src/github.com/greenplum-db/gpbackup"
+PATH=$PATH:/opt/go/bin:~/go/bin GOPATH=~/go make depend build install integration end_to_end -C /home/gpadmin/go/src/github.com/greenplum-db/gpbackup"


### PR DESCRIPTION
Run gpbackup unit-tests on github actions

1) Fix golang version to run [gpbackup unit tests](https://github.com/arenadata/gpbackup/blob/master/.github/workflows/build_and_unit_test.yml) on github actions
2) Remove unit test run from our regression [test suite](https://github.com/arenadata/gpbackup/blob/85384fadf774560b87df4d30792644b87069583e/arenadata/run_gpbackup_tests.bash#L19C48-L19C86)

The failed test will be fixed, when https://github.com/arenadata/gpbackup/pull/49 will be done.