### PR TITLE
ADBDEV-4845: Fix gpbackup test runtime error: index out of range

### DIFF
--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -425,6 +425,7 @@ func formatContents(slice []string) string {
 }
 
 func formatDiffs(actual []string, expected []string) string {
+	Expect(len(actual)).To(Equal(len(expected)))
 	dmp := diffmatchpatch.New()
 	diffs := ""
 	for idx := range actual {


### PR DESCRIPTION
Fix gpbackup test runtime error: index out of range

gpbackup does not check the lengths of the slices and assumes that
they are always equal. This may result in an array out-of-bounds error
`gpbackup test runtime error: index out of range [4] with length 4`

This patch fixes it by adding assertion on lists lengths