### PR TITLE
ADBDEV-4534 Implement gpdb 7 support for gpbackup ordering patch

### DIFF
--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -856,7 +856,7 @@ func GetExtensions(connectionPool *dbconn.DBConn) []Extension {
 			UNION DISTINCT
 			SELECT e.oid, level + 1, e.extname, e.extnamespace
 			FROM cte JOIN e ON cte.oid = e.objid
-		) SELECT oid, quote_ident(extname) name, quote_ident(nspname) schema
+		) SELECT cte.oid, quote_ident(extname) name, quote_ident(nspname) schema
 		FROM cte JOIN pg_catalog.pg_namespace n ON extnamespace = n.oid
 		GROUP BY 1, 2, 3 ORDER BY max(level) DESC`
 	}

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -141,16 +141,11 @@ func getUserTableRelations(connectionPool *dbconn.DBConn) []Relation {
 		relkindFilter = `'r', 'p'`
 		prt = `LEFT JOIN (
 			SELECT
-				p.oid,
+				pg_partition_root(c.oid) oid,
 				sum(c.relpages) AS pages
-			FROM (
-				select oid
-				from pg_class
-				where relkind = 'p'
-				and oid not in (select inhrelid from pg_inherits)
-			) p, pg_partition_tree(p.oid)
-			JOIN pg_class c ON relid = c.oid
-			GROUP BY p.oid
+			FROM pg_class c
+			WHERE c.relispartition = true OR c.relkind = 'p'
+			GROUP BY 1
 		) AS prt ON prt.oid = c.oid`
 	}
 
@@ -195,16 +190,11 @@ func getUserTableRelationsWithIncludeFiltering(connectionPool *dbconn.DBConn, in
 		relkindFilter = `'r', 'p'`
 		prt = `LEFT JOIN (
 			SELECT
-				p.oid,
+				pg_partition_root(c.oid) oid,
 				sum(c.relpages) AS pages
-			FROM (
-				select oid
-				from pg_class
-				where relkind = 'p'
-				and oid not in (select inhrelid from pg_inherits)
-			) p, pg_partition_tree(p.oid)
-			JOIN pg_class c ON relid = c.oid
-			GROUP BY p.oid
+			FROM pg_class c
+			WHERE c.relispartition = true OR c.relkind = 'p'
+			GROUP BY 1
 		) AS prt ON prt.oid = c.oid`
 	}
 

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -143,7 +143,12 @@ func getUserTableRelations(connectionPool *dbconn.DBConn) []Relation {
 			SELECT
 				p.oid,
 				sum(c.relpages) AS pages
-			FROM pg_class p, pg_partition_tree(p.oid)
+			FROM (
+				select oid
+				from pg_class
+				where relkind = 'p'
+				and oid not in (select inhrelid from pg_inherits)
+			) p, pg_partition_tree(p.oid)
 			JOIN pg_class c ON relid = c.oid
 			GROUP BY p.oid
 		) AS prt ON prt.oid = c.oid`
@@ -192,7 +197,12 @@ func getUserTableRelationsWithIncludeFiltering(connectionPool *dbconn.DBConn, in
 			SELECT
 				p.oid,
 				sum(c.relpages) AS pages
-			FROM pg_class p, pg_partition_tree(p.oid)
+			FROM (
+				select oid
+				from pg_class
+				where relkind = 'p'
+				and oid not in (select inhrelid from pg_inherits)
+			) p, pg_partition_tree(p.oid)
 			JOIN pg_class c ON relid = c.oid
 			GROUP BY p.oid
 		) AS prt ON prt.oid = c.oid`


### PR DESCRIPTION
gpbackup used pg_partition and pg_partition_rule to select partitions for gpdb6
and prior, but gpdb7 ditched them. This patch adds a new query for gpdb7 which
uses pg_partition_root. Also, gpdb7 complains on the query from GetExtension
saying that it's ambiguous. This patch also fixes it