### PR TITLE
ADBDEV-4738: Rework patch that solves function-table type dependency issue

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -242,18 +242,20 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 
 	var protocols []ExternalProtocol
 	var functions []Function
+	var dependentFunctions []Function
 	var funcInfoMap map[uint32]FunctionInfo
 	objects := make([]Sortable, 0)
 	metadataMap := make(MetadataMap)
 
 	if !tableOnly {
-		functions, funcInfoMap = retrieveFunctions(&objects, metadataMap)
+		functions, dependentFunctions, funcInfoMap = retrieveFunctions(&objects, metadataMap)
 	}
 	objects = append(objects, convertToSortableSlice(tables)...)
 	relationMetadata := GetMetadataForObjectType(connectionPool, TYPE_RELATION)
 	addToMetadataMap(relationMetadata, metadataMap)
 
 	if !tableOnly {
+		objects = append(objects, convertToSortableSlice(dependentFunctions)...)
 		protocols = retrieveProtocols(&objects, metadataMap)
 		backupSchemas(metadataFile, createAlteredPartitionSchemaSet(tables))
 		backupExtensions(metadataFile)

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -36,6 +36,7 @@ type Function struct {
 	NumRows           float32 `db:"prorows"`
 	DataAccess        string  `db:"prodataaccess"`
 	Language          string
+	IsDependOnTables  bool   `db:"prodep"`
 	Kind              string `db:"prokind"`     // GPDB 7+
 	PlannerSupport    string `db:"prosupport"`  // GPDB 7+
 	IsWindow          bool   `db:"proiswindow"` // before 7
@@ -102,6 +103,12 @@ func GetFunctionsAllVersions(connectionPool *dbconn.DBConn) []Function {
 }
 
 func GetFunctions(connectionPool *dbconn.DBConn) []Function {
+	isDependOnTablesClause := `EXISTS (
+		SELECT c.oid
+		FROM pg_class c
+		JOIN pg_type t ON t.oid IN (SELECT unnest(p.proargtypes||p.prorettype))
+		WHERE c.relkind = 'r' AND c.reltype IN (t.oid, t.typelem)
+	) AS prodep`
 	excludeImplicitFunctionsClause := ""
 	if connectionPool.Version.AtLeast("6") {
 		// This excludes implicitly created functions. Currently this is only range type functions
@@ -140,14 +147,15 @@ func GetFunctions(connectionPool *dbconn.DBConn) []Function {
 			procost,
 			prorows,
 			prodataaccess,
-			l.lanname AS language
+			l.lanname AS language,
+			%s
 		FROM pg_proc p
 			JOIN pg_catalog.pg_language l ON p.prolang = l.oid
 			LEFT JOIN pg_namespace n ON p.pronamespace = n.oid
 		WHERE %s
 			AND proisagg = 'f'
 			AND %s%s
-		ORDER BY nspname, proname, identargs`, locationAtts,
+		ORDER BY nspname, proname, identargs`, locationAtts, isDependOnTablesClause,
 		SchemaFilterClause("n"),
 		ExtensionFilterClause("p"),
 		excludeImplicitFunctionsClause)
@@ -173,6 +181,7 @@ func GetFunctions(connectionPool *dbconn.DBConn) []Function {
 			prokind,
 			prosupport,
 			l.lanname AS language,
+			%s
             coalesce(array_to_string(ARRAY(SELECT 'FOR TYPE ' || nm.nspname || '.' || typ.typname
                 from
                     unnest(p.protrftypes) as trf_unnest
@@ -187,7 +196,7 @@ func GetFunctions(connectionPool *dbconn.DBConn) []Function {
 		WHERE %s
 			AND prokind <> 'a'
 			AND %s%s
-		ORDER BY nspname, proname, identargs`, locationAtts,
+		ORDER BY nspname, proname, identargs`, locationAtts, isDependOnTablesClause,
 		SchemaFilterClause("n"),
 		ExtensionFilterClause("p"),
 		excludeImplicitFunctionsClause)

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -223,16 +223,25 @@ func RetrieveAndProcessTables() ([]Table, []Table, []Table) {
 	return metadataTables, dataTables, allTables
 }
 
-func retrieveFunctions(sortables *[]Sortable, metadataMap MetadataMap) ([]Function, map[uint32]FunctionInfo) {
+func retrieveFunctions(sortables *[]Sortable, metadataMap MetadataMap) ([]Function, []Function, map[uint32]FunctionInfo) {
 	gplog.Verbose("Retrieving function information")
 	functionMetadata := GetMetadataForObjectType(connectionPool, TYPE_FUNCTION)
 	addToMetadataMap(functionMetadata, metadataMap)
 	functions := GetFunctionsAllVersions(connectionPool)
 	funcInfoMap := GetFunctionOidToInfoMap(connectionPool)
 	objectCounts["Functions"] = len(functions)
-	*sortables = append(*sortables, convertToSortableSlice(functions)...)
+	independentFunctions := make([]Function, 0)
+	dependentFunctions := make([]Function, 0)
+	for _, function := range functions {
+		if function.IsDependOnTables {
+			dependentFunctions = append(dependentFunctions, function)
+		} else {
+			independentFunctions = append(independentFunctions, function)
+		}
+	}
+	*sortables = append(*sortables, convertToSortableSlice(independentFunctions)...)
 
-	return functions, funcInfoMap
+	return functions, dependentFunctions, funcInfoMap
 }
 
 func retrieveTransforms(sortables *[]Sortable) {

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1887,6 +1887,31 @@ LANGUAGE plpgsql NO SQL;`)
 
 				assertArtifactsCleaned(restoreConn, timestamp)
 			})
+			It("runs gpbackup and gprestore to backup functions depending on table row's type", func() {
+				skipIfOldBackupVersionBefore("1.19.0")
+
+				testhelper.AssertQueryRuns(backupConn, "CREATE TABLE table_provides_type (n int);")
+				defer testhelper.AssertQueryRuns(backupConn, "DROP TABLE table_provides_type;")
+
+				testhelper.AssertQueryRuns(backupConn, "INSERT INTO table_provides_type values (1);")
+				testhelper.AssertQueryRuns(backupConn, "CREATE OR REPLACE FUNCTION func_depends_on_row_type(arg table_provides_type[]) RETURNS void AS $$ BEGIN; SELECT NULL; END; $$ LANGUAGE SQL;")
+
+				defer testhelper.AssertQueryRuns(backupConn, "DROP FUNCTION func_depends_on_row_type(arg table_provides_type[]);")
+
+				timestamp := gpbackup(gpbackupPath, backupHelperPath)
+				gprestore(gprestorePath, restoreHelperPath, timestamp,
+					"--redirect-db", "restoredb")
+
+				assertRelationsCreated(restoreConn, TOTAL_RELATIONS+1) // for 1 new table
+				assertDataRestored(restoreConn, schema2TupleCounts)
+				assertDataRestored(restoreConn, map[string]int{
+					"public.foo":                 40000,
+					"public.holds":               50000,
+					"public.sales":               13,
+					"public.table_provides_type": 1})
+
+				assertArtifactsCleaned(restoreConn, timestamp)
+			})
 			It("Can restore xml with xmloption set to document", func() {
 				testutils.SkipIfBefore6(backupConn)
 				// Set up the XML table that contains XML content


### PR DESCRIPTION
Rework patch 11da7e0 that solves function-table type dependency issue

Patch 0c3ab91 backups functions before tables unconditionally.
In this case gprestore can not restore functions, that depend on tables
by arguments or return types.
This patch solves this issue by backup independent functions before
tables and dependent functions after.

Test is taken from 11da7e0