### PR TITLE
ADBDEV-4973: Fix syntax error on 7X Rework patch that solves function-table type dependency issue

### DIFF
--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -181,7 +181,6 @@ func GetFunctions(connectionPool *dbconn.DBConn) []Function {
 			prokind,
 			prosupport,
 			l.lanname AS language,
-			%s
             coalesce(array_to_string(ARRAY(SELECT 'FOR TYPE ' || nm.nspname || '.' || typ.typname
                 from
                     unnest(p.protrftypes) as trf_unnest
@@ -189,8 +188,9 @@ func GetFunctions(connectionPool *dbconn.DBConn) []Function {
                          on trf_unnest = typ.oid
 					left join pg_namespace nm
 						on typ.typnamespace = nm.oid
-                ), ', '), '') AS transformtypes
-		FROM pg_proc p
+                ), ', '), '') AS transformtypes,
+			%s
+				FROM pg_proc p
 			JOIN pg_catalog.pg_language l ON p.prolang = l.oid
 			LEFT JOIN pg_namespace n ON p.pronamespace = n.oid
 		WHERE %s


### PR DESCRIPTION
Fix syntax error on 7X Rework patch that solves function-table type dependency issue

There was an SQL syntax error on 7X during the development of patch c0e6266.
This patch fixes it.