### PR TITLE
Adopt test scripts to run on 7x

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -1,3 +1,4 @@
-FROM hub.adsw.io/library/gpdb6_regress:latest
+ARG GPDB_IMAGE=gpdb6_regress:latest
+FROM hub.adsw.io/library/$GPDB_IMAGE
 
 COPY . /home/gpadmin/go/src/github.com/greenplum-db/gpbackup

--- a/arenadata/README.md
+++ b/arenadata/README.md
@@ -1,6 +1,13 @@
 ## How to run tests
 
+6x:
 ```bash
 docker build -t gpbackup:test -f arenadata/Dockerfile .
 docker run --rm -it --sysctl 'kernel.sem=500 1024000 200 4096' gpbackup:test bash -c "ssh-keygen -A && /usr/sbin/sshd && bash /home/gpadmin/go/src/github.com/greenplum-db/gpbackup/arenadata/run_gpbackup_tests.bash"
+```
+
+7x:
+```bash
+docker build -t gpbackup:test7x -f arenadata/Dockerfile --build-arg GPDB_IMAGE=gpdb7_regress:latest .
+docker run --rm -it --sysctl 'kernel.sem=500 1024000 200 4096' gpbackup:test7x bash -c "ssh-keygen -A && /usr/sbin/sshd && bash /home/gpadmin/go/src/github.com/greenplum-db/gpbackup/arenadata/run_gpbackup_tests.bash"
 ```

--- a/arenadata/run_gpbackup_tests.bash
+++ b/arenadata/run_gpbackup_tests.bash
@@ -2,10 +2,19 @@
 
 set -eox pipefail
 
+# 7x has additional tests with de_DE locale. Install the missing.
+# 6x has no such package and following commands are excessive, but it's not an error.
+yum install -y glibc-locale-source || true
+localedef -i de_DE -f UTF-8 de_DE
+
 source gpdb_src/concourse/scripts/common.bash
 install_and_configure_gpdb
 make -C gpdb_src/src/test/regress/
-make -C gpdb_src/contrib/dummy_seclabel/ install
+# dummy_seclabel has different installation path for 6x and 7x. Try both.
+if ! make -C gpdb_src/contrib/dummy_seclabel/ install
+then
+	make -C gpdb_src/src/test/modules/dummy_seclabel/ install
+fi
 gpdb_src/concourse/scripts/setup_gpadmin_user.bash
 make_cluster
 


### PR DESCRIPTION
Adopt test scripts to run on 7x

This patch adds new commands to already existing files, so they can be used with
7x image.
Base image name in Dockerfile is parametrized now. The behavior is the same if
there is no value passed.
Bash script extended with locale installation. gpbackup contains 7x specific
tests with de_DE locale.
README was extended with additional instructions to run tests. Please use new
instructions to test this patch locally.
