### PR TITLE
ADBDEV-5112 Fix races detected in parallel metadata restore

### DIFF
--- a/utils/progress_bar.go
+++ b/utils/progress_bar.go
@@ -5,6 +5,7 @@ package utils
  */
 
 import (
+	"sync"
 	"time"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
@@ -61,6 +62,7 @@ type VerboseProgressBar struct {
 	prefix             string
 	nextPercentToPrint int
 	*pb.ProgressBar
+	mu sync.Mutex
 }
 
 func NewVerboseProgressBar(count int, prefix string) *VerboseProgressBar {
@@ -69,6 +71,8 @@ func NewVerboseProgressBar(count int, prefix string) *VerboseProgressBar {
 }
 
 func (vpb *VerboseProgressBar) Increment() int {
+	vpb.mu.Lock()
+	defer vpb.mu.Unlock()
 	vpb.ProgressBar.Increment()
 	if vpb.current < vpb.total {
 		vpb.current++


### PR DESCRIPTION
These commits are clean cherry-pick of upstream one (see hashes in the 
commit description). Initially the 1st one found on CI and the 2nd on build 
with race detector.

The 1st commit:

rying to assign channels to the map, and spin up a go routine that uses
the map in the same loop can result in the following panic at run time.

`fatal error: concurrent map read and map write`

This can also be detected using golang's race condition detector

The 2nd commit:

Our progress bar is not concurrency safe since many go routines may be
attempting to modify the values at the same time. Add a mutex to be used
by the progress bar for safe incrementing in go routines.

Without this fix the following issue is found by the golang race
detector
