### PR TITLE
ADBDEV-5228: Make the buffer for bufio Reader and Writer an adaptive size.

### DIFF
--- a/helper/backup_helper.go
+++ b/helper/backup_helper.go
@@ -120,7 +120,7 @@ func getBackupPipeReader(currentPipe string) (io.Reader, io.ReadCloser, error) {
 	// This is a workaround for https://github.com/golang/go/issues/24164.
 	// Once this bug is fixed, the call to Fd() can be removed
 	readHandle.Fd()
-	reader := bufio.NewReader(readHandle)
+	reader := bufio.NewReaderSize(readHandle, 65536)
 	return reader, readHandle, nil
 }
 

--- a/helper/backup_helper.go
+++ b/helper/backup_helper.go
@@ -120,7 +120,7 @@ func getBackupPipeReader(currentPipe string) (io.Reader, io.ReadCloser, error) {
 	// This is a workaround for https://github.com/golang/go/issues/24164.
 	// Once this bug is fixed, the call to Fd() can be removed
 	readHandle.Fd()
-	err, reader := utils.NewReader(readHandle, readHandle.Name())
+	reader, err := utils.NewReader(readHandle, readHandle.Name())
 	return reader, readHandle, err
 }
 

--- a/helper/backup_helper_pipes.go
+++ b/helper/backup_helper_pipes.go
@@ -33,7 +33,7 @@ func (cPipe CommonBackupPipeWriterCloser) Close() error {
 
 func NewCommonBackupPipeWriterCloser(writeHandle io.WriteCloser, name string) (cPipe CommonBackupPipeWriterCloser, err error) {
 	cPipe.writeHandle = writeHandle
-	err, cPipe.bufIoWriter = utils.NewWriter(writeHandle, name)
+	cPipe.bufIoWriter, err = utils.NewWriter(writeHandle, name)
 	cPipe.finalWriter = cPipe.bufIoWriter
 	return
 }

--- a/helper/backup_helper_pipes.go
+++ b/helper/backup_helper_pipes.go
@@ -32,7 +32,7 @@ func (cPipe CommonBackupPipeWriterCloser) Close() error {
 
 func NewCommonBackupPipeWriterCloser(writeHandle io.WriteCloser) (cPipe CommonBackupPipeWriterCloser) {
 	cPipe.writeHandle = writeHandle
-	cPipe.bufIoWriter = bufio.NewWriter(cPipe.writeHandle)
+	cPipe.bufIoWriter = bufio.NewWriterSize(cPipe.writeHandle, 65536)
 	cPipe.finalWriter = cPipe.bufIoWriter
 	return
 }

--- a/helper/restore_helper.go
+++ b/helper/restore_helper.go
@@ -452,7 +452,7 @@ func getRestoreDataReader(fileToRead string, objToc *toc.SegmentTOC, oidList []i
 			// error logging handled by calling functions
 			return nil, err
 		}
-		err, restoreReader.bufReader = utils.NewReader(gzipReader, name)
+		restoreReader.bufReader, err = utils.NewReader(gzipReader, name)
 		if err != nil {
 			// error logging handled by calling functions
 			return nil, err
@@ -463,13 +463,13 @@ func getRestoreDataReader(fileToRead string, objToc *toc.SegmentTOC, oidList []i
 			// error logging handled by calling functions
 			return nil, err
 		}
-		err, restoreReader.bufReader = utils.NewReader(zstdReader, name)
+		restoreReader.bufReader, err = utils.NewReader(zstdReader, name)
 		if err != nil {
 			// error logging handled by calling functions
 			return nil, err
 		}
 	} else {
-		err, restoreReader.bufReader = utils.NewReader(readHandle, name)
+		restoreReader.bufReader, err = utils.NewReader(readHandle, name)
 		if err != nil {
 			// error logging handled by calling functions
 			return nil, err
@@ -498,7 +498,7 @@ func getRestorePipeWriter(currentPipe string) (*bufio.Writer, *os.File, error) {
 	// adopting the new kernel, we must only use the bare essential methods Write() and
 	// Close() for the pipe to avoid an extra buffer read that can happen in error
 	// scenarios with --on-error-continue.
-	err, pipeWriter := utils.NewWriter(struct{ io.WriteCloser }{fileHandle}, fileHandle.Name())
+	pipeWriter, err := utils.NewWriter(struct{ io.WriteCloser }{fileHandle}, fileHandle.Name())
 
 	return pipeWriter, fileHandle, err
 }
@@ -516,7 +516,7 @@ func startRestorePluginCommand(fileToRead string, objToc *toc.SegmentTOC, oidLis
 		defer func() {
 			offsetsFile.Close()
 		}()
-		err, w := utils.NewWriter(offsetsFile, offsetsFile.Name())
+		w, err := utils.NewWriter(offsetsFile, offsetsFile.Name())
 		if err != nil {
 			// error logging handled by calling functions
 			return nil, false, err

--- a/helper/restore_helper.go
+++ b/helper/restore_helper.go
@@ -448,16 +448,16 @@ func getRestoreDataReader(fileToRead string, objToc *toc.SegmentTOC, oidList []i
 			// error logging handled by calling functions
 			return nil, err
 		}
-		restoreReader.bufReader = bufio.NewReader(gzipReader)
+		restoreReader.bufReader = bufio.NewReaderSize(gzipReader, 65536)
 	} else if strings.HasSuffix(fileToRead, ".zst") {
 		zstdReader, err := zstd.NewReader(readHandle)
 		if err != nil {
 			// error logging handled by calling functions
 			return nil, err
 		}
-		restoreReader.bufReader = bufio.NewReader(zstdReader)
+		restoreReader.bufReader = bufio.NewReaderSize(zstdReader, 65536)
 	} else {
-		restoreReader.bufReader = bufio.NewReader(readHandle)
+		restoreReader.bufReader = bufio.NewReaderSize(readHandle, 65536)
 	}
 
 	// Check that no error has occurred in plugin command
@@ -482,7 +482,7 @@ func getRestorePipeWriter(currentPipe string) (*bufio.Writer, *os.File, error) {
 	// adopting the new kernel, we must only use the bare essential methods Write() and
 	// Close() for the pipe to avoid an extra buffer read that can happen in error
 	// scenarios with --on-error-continue.
-	pipeWriter := bufio.NewWriter(struct{ io.WriteCloser }{fileHandle})
+	pipeWriter := bufio.NewWriterSize(struct{ io.WriteCloser }{fileHandle}, 65536)
 
 	return pipeWriter, fileHandle, nil
 }
@@ -500,7 +500,7 @@ func startRestorePluginCommand(fileToRead string, objToc *toc.SegmentTOC, oidLis
 		defer func() {
 			offsetsFile.Close()
 		}()
-		w := bufio.NewWriter(offsetsFile)
+		w := bufio.NewWriterSize(offsetsFile, 65536)
 		w.WriteString(fmt.Sprintf("%v", len(oidList)))
 
 		for _, oid := range oidList {

--- a/helper/restore_helper.go
+++ b/helper/restore_helper.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -412,6 +413,7 @@ func getRestoreDataReader(fileToRead string, objToc *toc.SegmentTOC, oidList []i
 	var seekHandle io.ReadSeeker
 	var isSubset bool
 	var err error = nil
+	var name string
 	restoreReader := new(RestoreReader)
 
 	if *pluginConfigFile != "" {
@@ -423,6 +425,7 @@ func getRestoreDataReader(fileToRead string, objToc *toc.SegmentTOC, oidList []i
 			// Regular reader which doesn't support seek
 			restoreReader.readerType = NONSEEKABLE
 		}
+		name = filepath.Dir(fileToRead)
 	} else {
 		if *isFiltered && !strings.HasSuffix(fileToRead, ".gz") && !strings.HasSuffix(fileToRead, ".zst") {
 			// Seekable reader if backup is not compressed and filters are set
@@ -433,6 +436,7 @@ func getRestoreDataReader(fileToRead string, objToc *toc.SegmentTOC, oidList []i
 			readHandle, err = os.Open(fileToRead)
 			restoreReader.readerType = NONSEEKABLE
 		}
+		name = fileToRead
 	}
 	if err != nil {
 		// error logging handled by calling functions
@@ -448,7 +452,7 @@ func getRestoreDataReader(fileToRead string, objToc *toc.SegmentTOC, oidList []i
 			// error logging handled by calling functions
 			return nil, err
 		}
-		err, restoreReader.bufReader = utils.NewReader(gzipReader, fileToRead)
+		err, restoreReader.bufReader = utils.NewReader(gzipReader, name)
 		if err != nil {
 			// error logging handled by calling functions
 			return nil, err
@@ -459,13 +463,13 @@ func getRestoreDataReader(fileToRead string, objToc *toc.SegmentTOC, oidList []i
 			// error logging handled by calling functions
 			return nil, err
 		}
-		err, restoreReader.bufReader = utils.NewReader(zstdReader, fileToRead)
+		err, restoreReader.bufReader = utils.NewReader(zstdReader, name)
 		if err != nil {
 			// error logging handled by calling functions
 			return nil, err
 		}
 	} else {
-		err, restoreReader.bufReader = utils.NewReader(readHandle, fileToRead)
+		err, restoreReader.bufReader = utils.NewReader(readHandle, name)
 		if err != nil {
 			// error logging handled by calling functions
 			return nil, err

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -1,7 +1,6 @@
 package restore
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"regexp"
@@ -712,7 +711,11 @@ func writeErrorTables(isMetadata bool) {
 		gplog.Warn("Unable to open error table file %s, skipping error report creation", errorFilename)
 		return
 	}
-	errorWriter := bufio.NewWriterSize(errorFile, 65536)
+	err, errorWriter := utils.NewWriter(errorFile, errorFile.Name())
+	if err != nil {
+		// error logging handled by calling functions
+		return
+	}
 	start := true
 	for table := range *errorTables {
 		if start == false {

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -711,7 +711,7 @@ func writeErrorTables(isMetadata bool) {
 		gplog.Warn("Unable to open error table file %s, skipping error report creation", errorFilename)
 		return
 	}
-	err, errorWriter := utils.NewWriter(errorFile, errorFile.Name())
+	errorWriter, err := utils.NewWriter(errorFile, errorFile.Name())
 	if err != nil {
 		// error logging handled by calling functions
 		return

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -712,7 +712,7 @@ func writeErrorTables(isMetadata bool) {
 		gplog.Warn("Unable to open error table file %s, skipping error report creation", errorFilename)
 		return
 	}
-	errorWriter := bufio.NewWriter(errorFile)
+	errorWriter := bufio.NewWriterSize(errorFile, 65536)
 	start := true
 	for table := range *errorTables {
 		if start == false {

--- a/utils/util.go
+++ b/utils/util.go
@@ -283,22 +283,20 @@ func GetFileHash(filename string) ([32]byte, error) {
 	return filehash, nil
 }
 
-func NewWriter(w io.Writer, name string) (error, *bufio.Writer) {
+func NewWriter(w io.Writer, name string) (*bufio.Writer, error) {
 	stat := syscall.Statfs_t{}
 	err := syscall.Statfs(name, &stat)
 	if err != nil {
-		gplog.Warn("Unable to stat file %s", name)
-		return err, nil
+		gplog.Error("Unable to stat file %s: %v", name, err)
 	}
-	return nil, bufio.NewWriterSize(w, int(stat.Bsize))
+	return bufio.NewWriterSize(w, int(stat.Bsize)), err
 }
 
-func NewReader(r io.Reader, name string) (error, *bufio.Reader) {
+func NewReader(r io.Reader, name string) (*bufio.Reader, error) {
 	stat := syscall.Statfs_t{}
 	err := syscall.Statfs(name, &stat)
 	if err != nil {
-		gplog.Warn("Unable to stat file %s", name)
-		return err, nil
+		gplog.Error("Unable to stat file %s: %v", name, err)
 	}
-	return nil, bufio.NewReaderSize(r, int(stat.Bsize))
+	return bufio.NewReaderSize(r, int(stat.Bsize)), err
 }

--- a/utils/util.go
+++ b/utils/util.go
@@ -6,14 +6,17 @@ package utils
  */
 
 import (
+	"bufio"
 	"crypto/sha256"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
 	path "path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
@@ -278,4 +281,24 @@ func GetFileHash(filename string) ([32]byte, error) {
 		return [32]byte{}, err
 	}
 	return filehash, nil
+}
+
+func NewWriter(w io.Writer, name string) (error, *bufio.Writer) {
+	stat := syscall.Statfs_t{}
+	err := syscall.Statfs(name, &stat)
+	if err != nil {
+		gplog.Warn("Unable to stat file %s", name)
+		return err, nil
+	}
+	return nil, bufio.NewWriterSize(w, int(stat.Bsize))
+}
+
+func NewReader(r io.Reader, name string) (error, *bufio.Reader) {
+	stat := syscall.Statfs_t{}
+	err := syscall.Statfs(name, &stat)
+	if err != nil {
+		gplog.Warn("Unable to stat file %s", name)
+		return err, nil
+	}
+	return nil, bufio.NewReaderSize(r, int(stat.Bsize))
 }


### PR DESCRIPTION
Make the buffer for bufio Reader and Writer an adaptive size.

The bufio package's Reader and Writer classes have a default buffer size of 4
kilobytes. At the same time, the cat console utility uses the file system block
size for the buffer. If this size differs from 4 kilobytes, then the backup
speed may slow down significantly. This patch sizes the bufio package's Reader
and Writer class buffers to the filesystem block size. This way the buffers will
have the same size.