### PR TITLE
ADBDEV-5228-flag: New default-buffer-size option

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -313,7 +313,7 @@ func backupData(tables []Table) {
 		initialPipes := CreateInitialSegmentPipes(oidList, globalCluster, connectionPool, globalFPInfo)
 		// Do not pass through the --on-error-continue flag or the resizeClusterMap because neither apply to gpbackup
 		utils.StartGpbackupHelpers(globalCluster, globalFPInfo, "--backup-agent",
-			MustGetFlagString(options.PLUGIN_CONFIG), compressStr, false, false, &wasTerminated, initialPipes, true, false, 0, 0)
+			MustGetFlagString(options.PLUGIN_CONFIG), compressStr, false, false, &wasTerminated, initialPipes, true, false, 0, 0, MustGetFlagInt(options.DEFAULT_BUFFER_SIZE))
 	}
 	gplog.Info("Writing data to file")
 	rowsCopiedMaps := BackupDataForAllTables(tables)

--- a/backup/validate.go
+++ b/backup/validate.go
@@ -175,6 +175,9 @@ func validateFlagCombinations(flags *pflag.FlagSet) {
 	if FlagChanged(options.SINGLE_BACKUP_DIR) && !FlagChanged(options.BACKUP_DIR) {
 		gplog.Fatal(errors.Errorf("--single-backup-dir must be specified with --backup-dir"), "")
 	}
+	if FlagChanged(options.DEFAULT_BUFFER_SIZE) && !MustGetFlagBool(options.SINGLE_DATA_FILE) {
+		gplog.Fatal(errors.Errorf("--default-buffer-size must be specified with --single-data-file"), "")
+	}
 }
 
 func validateFlagValues() {
@@ -191,6 +194,10 @@ func validateFlagValues() {
 	if FlagChanged(options.COPY_QUEUE_SIZE) && MustGetFlagInt(options.COPY_QUEUE_SIZE) < 2 {
 		gplog.Fatal(errors.Errorf("--copy-queue-size %d is invalid. Must be at least 2",
 			MustGetFlagInt(options.COPY_QUEUE_SIZE)), "")
+	}
+	if FlagChanged(options.DEFAULT_BUFFER_SIZE) && MustGetFlagInt(options.DEFAULT_BUFFER_SIZE) < 1 {
+		gplog.Fatal(errors.Errorf("--default-buffer-size %d is invalid. Must be at least 1",
+			MustGetFlagInt(options.DEFAULT_BUFFER_SIZE)), "")
 	}
 }
 

--- a/backup/validate.go
+++ b/backup/validate.go
@@ -195,8 +195,8 @@ func validateFlagValues() {
 		gplog.Fatal(errors.Errorf("--copy-queue-size %d is invalid. Must be at least 2",
 			MustGetFlagInt(options.COPY_QUEUE_SIZE)), "")
 	}
-	if FlagChanged(options.DEFAULT_BUFFER_SIZE) && MustGetFlagInt(options.DEFAULT_BUFFER_SIZE) < 1 {
-		gplog.Fatal(errors.Errorf("--default-buffer-size %d is invalid. Must be at least 1",
+	if FlagChanged(options.DEFAULT_BUFFER_SIZE) && MustGetFlagInt(options.DEFAULT_BUFFER_SIZE) < 4 {
+		gplog.Fatal(errors.Errorf("--default-buffer-size %d is invalid. Must be at least 4",
 			MustGetFlagInt(options.DEFAULT_BUFFER_SIZE)), "")
 	}
 }

--- a/helper/backup_helper.go
+++ b/helper/backup_helper.go
@@ -120,7 +120,7 @@ func getBackupPipeReader(currentPipe string) (io.Reader, io.ReadCloser, error) {
 	// This is a workaround for https://github.com/golang/go/issues/24164.
 	// Once this bug is fixed, the call to Fd() can be removed
 	readHandle.Fd()
-	reader := bufio.NewReader(readHandle)
+	reader := bufio.NewReaderSize(readHandle, *defaultBufferSize)
 	return reader, readHandle, nil
 }
 

--- a/helper/backup_helper_pipes.go
+++ b/helper/backup_helper_pipes.go
@@ -32,7 +32,7 @@ func (cPipe CommonBackupPipeWriterCloser) Close() error {
 
 func NewCommonBackupPipeWriterCloser(writeHandle io.WriteCloser) (cPipe CommonBackupPipeWriterCloser) {
 	cPipe.writeHandle = writeHandle
-	cPipe.bufIoWriter = bufio.NewWriter(cPipe.writeHandle)
+	cPipe.bufIoWriter = bufio.NewWriterSize(cPipe.writeHandle, *defaultBufferSize)
 	cPipe.finalWriter = cPipe.bufIoWriter
 	return
 }

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -37,25 +37,26 @@ var (
  * Command-line flags
  */
 var (
-	backupAgent      *bool
-	compressionLevel *int
-	compressionType  *string
-	content          *int
-	dataFile         *string
-	oidFile          *string
-	onErrorContinue  *bool
-	pipeFile         *string
-	pluginConfigFile *string
-	printVersion     *bool
-	restoreAgent     *bool
-	tocFile          *string
-	isFiltered       *bool
-	copyQueue        *int
-	singleDataFile   *bool
-	isResizeRestore  *bool
-	origSize         *int
-	destSize         *int
-	replicationFile  *string
+	backupAgent       *bool
+	compressionLevel  *int
+	compressionType   *string
+	content           *int
+	dataFile          *string
+	oidFile           *string
+	onErrorContinue   *bool
+	pipeFile          *string
+	pluginConfigFile  *string
+	printVersion      *bool
+	restoreAgent      *bool
+	tocFile           *string
+	isFiltered        *bool
+	copyQueue         *int
+	singleDataFile    *bool
+	isResizeRestore   *bool
+	origSize          *int
+	destSize          *int
+	replicationFile   *string
+	defaultBufferSize *int
 )
 
 func DoHelper() {
@@ -108,6 +109,8 @@ func InitializeGlobals() {
 	origSize = flag.Int("orig-seg-count", 0, "Used with resize restore.  Gives the segment count of the backup.")
 	destSize = flag.Int("dest-seg-count", 0, "Used with resize restore.  Gives the segment count of the current cluster.")
 	replicationFile = flag.String("replication-file", "", "Used with resize restore.  Gives the list of replicated tables.")
+	defaultBufferSize = flag.Int("default-buffer-size", 4, "Default buffer size in KB for read and write")
+	*defaultBufferSize = *defaultBufferSize * 1024
 
 	if *onErrorContinue && !*restoreAgent {
 		fmt.Printf("--on-error-continue flag can only be used with --restore-agent flag")

--- a/helper/restore_helper.go
+++ b/helper/restore_helper.go
@@ -448,16 +448,16 @@ func getRestoreDataReader(fileToRead string, objToc *toc.SegmentTOC, oidList []i
 			// error logging handled by calling functions
 			return nil, err
 		}
-		restoreReader.bufReader = bufio.NewReader(gzipReader)
+		restoreReader.bufReader = bufio.NewReaderSize(gzipReader, *defaultBufferSize)
 	} else if strings.HasSuffix(fileToRead, ".zst") {
 		zstdReader, err := zstd.NewReader(readHandle)
 		if err != nil {
 			// error logging handled by calling functions
 			return nil, err
 		}
-		restoreReader.bufReader = bufio.NewReader(zstdReader)
+		restoreReader.bufReader = bufio.NewReaderSize(zstdReader, *defaultBufferSize)
 	} else {
-		restoreReader.bufReader = bufio.NewReader(readHandle)
+		restoreReader.bufReader = bufio.NewReaderSize(readHandle, *defaultBufferSize)
 	}
 
 	// Check that no error has occurred in plugin command
@@ -482,7 +482,7 @@ func getRestorePipeWriter(currentPipe string) (*bufio.Writer, *os.File, error) {
 	// adopting the new kernel, we must only use the bare essential methods Write() and
 	// Close() for the pipe to avoid an extra buffer read that can happen in error
 	// scenarios with --on-error-continue.
-	pipeWriter := bufio.NewWriter(struct{ io.WriteCloser }{fileHandle})
+	pipeWriter := bufio.NewWriterSize(struct{ io.WriteCloser }{fileHandle}, *defaultBufferSize)
 
 	return pipeWriter, fileHandle, nil
 }
@@ -500,7 +500,7 @@ func startRestorePluginCommand(fileToRead string, objToc *toc.SegmentTOC, oidLis
 		defer func() {
 			offsetsFile.Close()
 		}()
-		w := bufio.NewWriter(offsetsFile)
+		w := bufio.NewWriterSize(offsetsFile, *defaultBufferSize)
 		w.WriteString(fmt.Sprintf("%v", len(oidList)))
 
 		for _, oid := range oidList {

--- a/options/flag.go
+++ b/options/flag.go
@@ -54,6 +54,7 @@ const (
 	RESIZE_CLUSTER        = "resize-cluster"
 	NO_INHERITS           = "no-inherits"
 	REPORT_DIR            = "report-dir"
+	DEFAULT_BUFFER_SIZE   = "default-buffer-size"
 )
 
 func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
@@ -89,6 +90,7 @@ func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.Bool(WITH_STATS, false, "Back up query plan statistics")
 	flagSet.Bool(WITHOUT_GLOBALS, false, "Skip backup of global metadata")
 	flagSet.Bool(NO_INHERITS, false, "For a filtered backup, don't back up all tables that inherit included tables")
+	flagSet.Int(DEFAULT_BUFFER_SIZE, 4, "Default buffer size in KB for read and write")
 }
 
 func SetRestoreFlagDefaults(flagSet *pflag.FlagSet) {
@@ -125,6 +127,7 @@ func SetRestoreFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.Bool(RESIZE_CLUSTER, false, "Restore a backup taken on a cluster with more or fewer segments than the cluster to which it will be restored")
 	flagSet.String(REPORT_DIR, "", "The absolute path of the directory to which restore report and error tables will be written")
 	_ = flagSet.MarkHidden(LEAF_PARTITION_DATA)
+	flagSet.Int(DEFAULT_BUFFER_SIZE, 4, "Default buffer size in KB for read and write")
 }
 
 /*

--- a/restore/data.go
+++ b/restore/data.go
@@ -201,7 +201,7 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Co
 		if backupConfig.Compressed {
 			compressStr = fmt.Sprintf(" --compression-type %s ", utils.GetPipeThroughProgram().Name)
 		}
-		utils.StartGpbackupHelpers(globalCluster, fpInfo, "--restore-agent", MustGetFlagString(options.PLUGIN_CONFIG), compressStr, MustGetFlagBool(options.ON_ERROR_CONTINUE), isFilter, &wasTerminated, initialPipes, backupConfig.SingleDataFile, resizeCluster, origSize, destSize)
+		utils.StartGpbackupHelpers(globalCluster, fpInfo, "--restore-agent", MustGetFlagString(options.PLUGIN_CONFIG), compressStr, MustGetFlagBool(options.ON_ERROR_CONTINUE), isFilter, &wasTerminated, initialPipes, backupConfig.SingleDataFile, resizeCluster, origSize, destSize, MustGetFlagInt(options.DEFAULT_BUFFER_SIZE))
 	}
 	/*
 	 * We break when an interrupt is received and rely on

--- a/restore/validate.go
+++ b/restore/validate.go
@@ -241,6 +241,9 @@ func ValidateBackupFlagCombinations() {
 	if !backupConfig.SingleDataFile && FlagChanged(options.COPY_QUEUE_SIZE) {
 		gplog.Fatal(errors.Errorf("The --copy-queue-size flag can only be used if the backup was taken with --single-data-file"), "")
 	}
+	if !backupConfig.SingleDataFile && FlagChanged(options.DEFAULT_BUFFER_SIZE) {
+		gplog.Fatal(errors.Errorf("The --default-buffer-size flag can only be used if the backup was taken with --single-data-file"), "")
+	}
 	validateBackupFlagPluginCombinations()
 }
 

--- a/utils/agent_remote.go
+++ b/utils/agent_remote.go
@@ -127,7 +127,7 @@ func VerifyHelperVersionOnSegments(version string, c *cluster.Cluster) {
 	}
 }
 
-func StartGpbackupHelpers(c *cluster.Cluster, fpInfo filepath.FilePathInfo, operation string, pluginConfigFile string, compressStr string, onErrorContinue bool, isFilter bool, wasTerminated *bool, copyQueue int, isSingleDataFile bool, resizeCluster bool, origSize int, destSize int) {
+func StartGpbackupHelpers(c *cluster.Cluster, fpInfo filepath.FilePathInfo, operation string, pluginConfigFile string, compressStr string, onErrorContinue bool, isFilter bool, wasTerminated *bool, copyQueue int, isSingleDataFile bool, resizeCluster bool, origSize int, destSize int, defaultBufferSize int) {
 	// A mutex lock for cleaning up and starting gpbackup helpers prevents a
 	// race condition that causes gpbackup_helpers to be orphaned if
 	// gpbackup_helper cleanup happens before they are started.
@@ -167,8 +167,8 @@ func StartGpbackupHelpers(c *cluster.Cluster, fpInfo filepath.FilePathInfo, oper
 		pipeFile := fpInfo.GetSegmentPipeFilePath(contentID)
 		backupFile := fpInfo.GetTableBackupFilePath(contentID, 0, GetPipeThroughProgram().Extension, true)
 		replicatedOidFile := fpInfo.GetSegmentHelperFilePath(contentID, "replicated_oid")
-		helperCmdStr := fmt.Sprintf(`gpbackup_helper %s --toc-file %s --oid-file %s --pipe-file %s --data-file "%s" --content %d%s%s%s%s%s%s --copy-queue-size %d --replication-file %s`,
-			operation, tocFile, oidFile, pipeFile, backupFile, contentID, pluginStr, compressStr, onErrorContinueStr, filterStr, singleDataFileStr, resizeStr, copyQueue, replicatedOidFile)
+		helperCmdStr := fmt.Sprintf(`gpbackup_helper %s --toc-file %s --oid-file %s --pipe-file %s --data-file "%s" --content %d%s%s%s%s%s%s --copy-queue-size %d --replication-file %s --default-buffer-size %d`,
+			operation, tocFile, oidFile, pipeFile, backupFile, contentID, pluginStr, compressStr, onErrorContinueStr, filterStr, singleDataFileStr, resizeStr, copyQueue, replicatedOidFile, defaultBufferSize)
 		// we run these commands in sequence to ensure that any failure is critical; the last command ensures the agent process was successfully started
 		return fmt.Sprintf(`cat << HEREDOC > %[1]s && chmod +x %[1]s && ( nohup %[1]s &> /dev/null &)
 #!/bin/bash

--- a/utils/agent_remote_test.go
+++ b/utils/agent_remote_test.go
@@ -138,6 +138,13 @@ var _ = Describe("agent remote", func() {
 			cc := testExecutor.ClusterCommands[0]
 			Expect(cc[1].CommandString).To(ContainSubstring(" --copy-queue-size 4"))
 		})
+		It("Correctly propagates --default-buffer-size value to gpbackup_helper", func() {
+			wasTerminated := false
+			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", false, false, &wasTerminated, 4, true, false, 0, 0, 64)
+
+			cc := testExecutor.ClusterCommands[0]
+			Expect(cc[1].CommandString).To(ContainSubstring(" --default-buffer-size 64"))
+		})
 	})
 	Describe("CheckAgentErrorsOnSegments", func() {
 		It("constructs the correct ssh call to check for the existance of an error file on each segment", func() {

--- a/utils/agent_remote_test.go
+++ b/utils/agent_remote_test.go
@@ -126,14 +126,14 @@ var _ = Describe("agent remote", func() {
 	Describe("StartGpbackupHelpers()", func() {
 		It("Correctly propagates --on-error-continue flag to gpbackup_helper", func() {
 			wasTerminated := false
-			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", true, false, &wasTerminated, 1, true, false, 0, 0)
+			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", true, false, &wasTerminated, 1, true, false, 0, 0, 4)
 
 			cc := testExecutor.ClusterCommands[0]
 			Expect(cc[1].CommandString).To(ContainSubstring(" --on-error-continue"))
 		})
 		It("Correctly propagates --copy-queue-size value to gpbackup_helper", func() {
 			wasTerminated := false
-			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", false, false, &wasTerminated, 4, true, false, 0, 0)
+			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", false, false, &wasTerminated, 4, true, false, 0, 0, 4)
 
 			cc := testExecutor.ClusterCommands[0]
 			Expect(cc[1].CommandString).To(ContainSubstring(" --copy-queue-size 4"))


### PR DESCRIPTION
The cat command from Centos 7 coreutils 8.22 uses a buffer size equal to the maximum of [64](https://github.com/coreutils/coreutils/blob/338446102698fa513ee399345811cb91827d05e5/src/ioblksize.h#L67-L72) kilobytes and the file system block size, which can be found with the following command
```sh
stat -fc %s .
```
Newer versions of the cat command use [128](https://github.com/coreutils/coreutils/blob/725bb111bda62d8446a0beed366bd9d2c06c8eff/src/ioblksize.h#L73-L78) or even [256](https://github.com/coreutils/coreutils/blob/606f54d157c3d9d558bdbe41da8d108993d86aeb/src/ioblksize.h#L78-L110) kilobytes. Moreover, in the latest versions this is not just a maximum, but a much more complex algorithm.

At the same time, gpbackup for [read](https://github.com/search?q=repo%3Aarenadata%2Fgpbackup%20bufio.NewReader&type=code) and [write](https://github.com/search?q=repo%3Aarenadata%2Fgpbackup%20bufio.NewWriter&type=code) uses the buffer size from the bufio package, which is [4 kilobytes](https://github.com/golang/go/blob/50dcffb384cf1693fb113de01c8a36debc6086d1/src/bufio/bufio.go#L19) by default.

Therefore, this patch makes a new option default-buffer-size, when set, gpbackup will use the specified buffer size instead of the default 4 kilobytes.