### PR TITLE
ADBDEV-5228: make 256KB buffer for read and write

### DIFF
--- a/helper/backup_helper.go
+++ b/helper/backup_helper.go
@@ -120,7 +120,7 @@ func getBackupPipeReader(currentPipe string) (io.Reader, io.ReadCloser, error) {
 	// This is a workaround for https://github.com/golang/go/issues/24164.
 	// Once this bug is fixed, the call to Fd() can be removed
 	readHandle.Fd()
-	reader := bufio.NewReader(readHandle)
+	reader := bufio.NewReaderSize(readHandle, 65536)
 	return reader, readHandle, nil
 }
 

--- a/helper/backup_helper.go
+++ b/helper/backup_helper.go
@@ -120,7 +120,7 @@ func getBackupPipeReader(currentPipe string) (io.Reader, io.ReadCloser, error) {
 	// This is a workaround for https://github.com/golang/go/issues/24164.
 	// Once this bug is fixed, the call to Fd() can be removed
 	readHandle.Fd()
-	reader := bufio.NewReaderSize(readHandle, 262144)
+	reader := bufio.NewReaderSize(readHandle, defaultBufferSize)
 	return reader, readHandle, nil
 }
 

--- a/helper/backup_helper.go
+++ b/helper/backup_helper.go
@@ -120,7 +120,7 @@ func getBackupPipeReader(currentPipe string) (io.Reader, io.ReadCloser, error) {
 	// This is a workaround for https://github.com/golang/go/issues/24164.
 	// Once this bug is fixed, the call to Fd() can be removed
 	readHandle.Fd()
-	reader := bufio.NewReaderSize(readHandle, 65536)
+	reader := bufio.NewReaderSize(readHandle, 262144)
 	return reader, readHandle, nil
 }
 

--- a/helper/backup_helper_pipes.go
+++ b/helper/backup_helper_pipes.go
@@ -32,7 +32,7 @@ func (cPipe CommonBackupPipeWriterCloser) Close() error {
 
 func NewCommonBackupPipeWriterCloser(writeHandle io.WriteCloser) (cPipe CommonBackupPipeWriterCloser) {
 	cPipe.writeHandle = writeHandle
-	cPipe.bufIoWriter = bufio.NewWriterSize(cPipe.writeHandle, 65536)
+	cPipe.bufIoWriter = bufio.NewWriterSize(cPipe.writeHandle, 262144)
 	cPipe.finalWriter = cPipe.bufIoWriter
 	return
 }

--- a/helper/backup_helper_pipes.go
+++ b/helper/backup_helper_pipes.go
@@ -32,7 +32,7 @@ func (cPipe CommonBackupPipeWriterCloser) Close() error {
 
 func NewCommonBackupPipeWriterCloser(writeHandle io.WriteCloser) (cPipe CommonBackupPipeWriterCloser) {
 	cPipe.writeHandle = writeHandle
-	cPipe.bufIoWriter = bufio.NewWriter(cPipe.writeHandle)
+	cPipe.bufIoWriter = bufio.NewWriterSize(cPipe.writeHandle, 65536)
 	cPipe.finalWriter = cPipe.bufIoWriter
 	return
 }

--- a/helper/backup_helper_pipes.go
+++ b/helper/backup_helper_pipes.go
@@ -32,7 +32,7 @@ func (cPipe CommonBackupPipeWriterCloser) Close() error {
 
 func NewCommonBackupPipeWriterCloser(writeHandle io.WriteCloser) (cPipe CommonBackupPipeWriterCloser) {
 	cPipe.writeHandle = writeHandle
-	cPipe.bufIoWriter = bufio.NewWriterSize(cPipe.writeHandle, 262144)
+	cPipe.bufIoWriter = bufio.NewWriterSize(cPipe.writeHandle, defaultBufferSize)
 	cPipe.finalWriter = cPipe.bufIoWriter
 	return
 }

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -19,6 +19,10 @@ import (
 	"github.com/greenplum-db/gpbackup/utils"
 )
 
+const (
+	defaultBufferSize = 262144
+)
+
 /*
  * Non-flag variables
  */

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	defaultBufferSize = 262144
+	defaultBufferSize = 256 * 1024
 )
 
 /*

--- a/helper/restore_helper.go
+++ b/helper/restore_helper.go
@@ -448,16 +448,16 @@ func getRestoreDataReader(fileToRead string, objToc *toc.SegmentTOC, oidList []i
 			// error logging handled by calling functions
 			return nil, err
 		}
-		restoreReader.bufReader = bufio.NewReader(gzipReader)
+		restoreReader.bufReader = bufio.NewReaderSize(gzipReader, 65536)
 	} else if strings.HasSuffix(fileToRead, ".zst") {
 		zstdReader, err := zstd.NewReader(readHandle)
 		if err != nil {
 			// error logging handled by calling functions
 			return nil, err
 		}
-		restoreReader.bufReader = bufio.NewReader(zstdReader)
+		restoreReader.bufReader = bufio.NewReaderSize(zstdReader, 65536)
 	} else {
-		restoreReader.bufReader = bufio.NewReader(readHandle)
+		restoreReader.bufReader = bufio.NewReaderSize(readHandle, 65536)
 	}
 
 	// Check that no error has occurred in plugin command
@@ -482,7 +482,7 @@ func getRestorePipeWriter(currentPipe string) (*bufio.Writer, *os.File, error) {
 	// adopting the new kernel, we must only use the bare essential methods Write() and
 	// Close() for the pipe to avoid an extra buffer read that can happen in error
 	// scenarios with --on-error-continue.
-	pipeWriter := bufio.NewWriter(struct{ io.WriteCloser }{fileHandle})
+	pipeWriter := bufio.NewWriterSize(struct{ io.WriteCloser }{fileHandle}, 65536)
 
 	return pipeWriter, fileHandle, nil
 }
@@ -500,7 +500,7 @@ func startRestorePluginCommand(fileToRead string, objToc *toc.SegmentTOC, oidLis
 		defer func() {
 			offsetsFile.Close()
 		}()
-		w := bufio.NewWriter(offsetsFile)
+		w := bufio.NewWriterSize(offsetsFile, 65536)
 		w.WriteString(fmt.Sprintf("%v", len(oidList)))
 
 		for _, oid := range oidList {

--- a/helper/restore_helper.go
+++ b/helper/restore_helper.go
@@ -448,16 +448,16 @@ func getRestoreDataReader(fileToRead string, objToc *toc.SegmentTOC, oidList []i
 			// error logging handled by calling functions
 			return nil, err
 		}
-		restoreReader.bufReader = bufio.NewReaderSize(gzipReader, 65536)
+		restoreReader.bufReader = bufio.NewReaderSize(gzipReader, 262144)
 	} else if strings.HasSuffix(fileToRead, ".zst") {
 		zstdReader, err := zstd.NewReader(readHandle)
 		if err != nil {
 			// error logging handled by calling functions
 			return nil, err
 		}
-		restoreReader.bufReader = bufio.NewReaderSize(zstdReader, 65536)
+		restoreReader.bufReader = bufio.NewReaderSize(zstdReader, 262144)
 	} else {
-		restoreReader.bufReader = bufio.NewReaderSize(readHandle, 65536)
+		restoreReader.bufReader = bufio.NewReaderSize(readHandle, 262144)
 	}
 
 	// Check that no error has occurred in plugin command
@@ -482,7 +482,7 @@ func getRestorePipeWriter(currentPipe string) (*bufio.Writer, *os.File, error) {
 	// adopting the new kernel, we must only use the bare essential methods Write() and
 	// Close() for the pipe to avoid an extra buffer read that can happen in error
 	// scenarios with --on-error-continue.
-	pipeWriter := bufio.NewWriterSize(struct{ io.WriteCloser }{fileHandle}, 65536)
+	pipeWriter := bufio.NewWriterSize(struct{ io.WriteCloser }{fileHandle}, 262144)
 
 	return pipeWriter, fileHandle, nil
 }
@@ -500,7 +500,7 @@ func startRestorePluginCommand(fileToRead string, objToc *toc.SegmentTOC, oidLis
 		defer func() {
 			offsetsFile.Close()
 		}()
-		w := bufio.NewWriterSize(offsetsFile, 65536)
+		w := bufio.NewWriterSize(offsetsFile, 262144)
 		w.WriteString(fmt.Sprintf("%v", len(oidList)))
 
 		for _, oid := range oidList {

--- a/helper/restore_helper.go
+++ b/helper/restore_helper.go
@@ -448,16 +448,16 @@ func getRestoreDataReader(fileToRead string, objToc *toc.SegmentTOC, oidList []i
 			// error logging handled by calling functions
 			return nil, err
 		}
-		restoreReader.bufReader = bufio.NewReaderSize(gzipReader, 262144)
+		restoreReader.bufReader = bufio.NewReaderSize(gzipReader, defaultBufferSize)
 	} else if strings.HasSuffix(fileToRead, ".zst") {
 		zstdReader, err := zstd.NewReader(readHandle)
 		if err != nil {
 			// error logging handled by calling functions
 			return nil, err
 		}
-		restoreReader.bufReader = bufio.NewReaderSize(zstdReader, 262144)
+		restoreReader.bufReader = bufio.NewReaderSize(zstdReader, defaultBufferSize)
 	} else {
-		restoreReader.bufReader = bufio.NewReaderSize(readHandle, 262144)
+		restoreReader.bufReader = bufio.NewReaderSize(readHandle, defaultBufferSize)
 	}
 
 	// Check that no error has occurred in plugin command
@@ -482,7 +482,7 @@ func getRestorePipeWriter(currentPipe string) (*bufio.Writer, *os.File, error) {
 	// adopting the new kernel, we must only use the bare essential methods Write() and
 	// Close() for the pipe to avoid an extra buffer read that can happen in error
 	// scenarios with --on-error-continue.
-	pipeWriter := bufio.NewWriterSize(struct{ io.WriteCloser }{fileHandle}, 262144)
+	pipeWriter := bufio.NewWriterSize(struct{ io.WriteCloser }{fileHandle}, defaultBufferSize)
 
 	return pipeWriter, fileHandle, nil
 }
@@ -500,7 +500,7 @@ func startRestorePluginCommand(fileToRead string, objToc *toc.SegmentTOC, oidLis
 		defer func() {
 			offsetsFile.Close()
 		}()
-		w := bufio.NewWriterSize(offsetsFile, 262144)
+		w := bufio.NewWriterSize(offsetsFile, defaultBufferSize)
 		w.WriteString(fmt.Sprintf("%v", len(oidList)))
 
 		for _, oid := range oidList {

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -712,7 +712,7 @@ func writeErrorTables(isMetadata bool) {
 		gplog.Warn("Unable to open error table file %s, skipping error report creation", errorFilename)
 		return
 	}
-	errorWriter := bufio.NewWriterSize(errorFile, 65536)
+	errorWriter := bufio.NewWriter(errorFile)
 	start := true
 	for table := range *errorTables {
 		if start == false {

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -712,7 +712,7 @@ func writeErrorTables(isMetadata bool) {
 		gplog.Warn("Unable to open error table file %s, skipping error report creation", errorFilename)
 		return
 	}
-	errorWriter := bufio.NewWriter(errorFile)
+	errorWriter := bufio.NewWriterSize(errorFile, 65536)
 	start := true
 	for table := range *errorTables {
 		if start == false {


### PR DESCRIPTION
make 256KB buffer for read and write

The bufio package's Reader and Writer classes have a default buffer size of 4
kilobytes. At the same time, the cat console utility from the coreutils 8.22
package in the Centos 7 operating system uses 64 kilobytes for the buffer. A
newer version of cat may use 128 or even 256 kilobytes for the buffer. In this
case, the backup speed may slow down significantly. This patch increases the
size of the bufio package's Reader and Writer class buffers to 256 kilobytes.