### PR TITLE
ADBDEV-5189: Make it possible to backup/restore extension config tables

### DIFF
--- a/backup/data.go
+++ b/backup/data.go
@@ -88,11 +88,11 @@ func CopyTableOut(connectionPool *dbconn.DBConn, table Table, destinationToWrite
 	}
 	tableName := table.FQN()
 	ignoreExternalPartitions := "IGNORE EXTERNAL PARTITIONS"
-	if table.ExtensionTableConfig != (ExtensionTableConfig{}) && table.ExtensionTableConfig.Condition != "" {
+	if table.ExtensionTableConfig != nil && *table.ExtensionTableConfig != "" {
 		if columnNames == "" {
 			columnNames = ConstructTableAttributesList(table.ColumnDefs)
 		}
-		tableName = fmt.Sprintf("(SELECT %s FROM %s %s)", columnNames[1:len(columnNames)-1], tableName, table.ExtensionTableConfig.Condition)
+		tableName = fmt.Sprintf("(SELECT %s FROM %s %s)", columnNames[1:len(columnNames)-1], tableName, *table.ExtensionTableConfig)
 		columnNames = ""
 		if connectionPool.Version.Before("7") {
 			ignoreExternalPartitions = ""

--- a/backup/data.go
+++ b/backup/data.go
@@ -89,7 +89,9 @@ func CopyTableOut(connectionPool *dbconn.DBConn, table Table, destinationToWrite
 	tableName := table.FQN()
 	ignoreExternalPartitions := "IGNORE EXTERNAL PARTITIONS"
 	if table.ExtensionTableConfig != (ExtensionTableConfig{}) && table.ExtensionTableConfig.Condition != "" {
-		columnNames = ConstructTableAttributesList(table.ColumnDefs)
+		if columnNames == "" {
+			columnNames = ConstructTableAttributesList(table.ColumnDefs)
+		}
 		tableName = fmt.Sprintf("(SELECT %s FROM %s %s)", columnNames[1:len(columnNames)-1], tableName, table.ExtensionTableConfig.Condition)
 		columnNames = ""
 		if connectionPool.Version.Before("7") {

--- a/backup/data.go
+++ b/backup/data.go
@@ -87,7 +87,7 @@ func CopyTableOut(connectionPool *dbconn.DBConn, table Table, destinationToWrite
 		columnNames = ConstructTableAttributesList(table.ColumnDefs)
 	}
 	tableName := table.FQN()
-	ignoreExternalPartitions := "IGNORE EXTERNAL PARTITIONS"
+	ignoreExternalPartitions := " IGNORE EXTERNAL PARTITIONS"
 	if table.ExtensionTableConfig != nil && *table.ExtensionTableConfig != "" {
 		if columnNames == "" {
 			columnNames = ConstructTableAttributesList(table.ColumnDefs)
@@ -99,7 +99,7 @@ func CopyTableOut(connectionPool *dbconn.DBConn, table Table, destinationToWrite
 		}
 	}
 
-	query := fmt.Sprintf("COPY %s%s TO %s WITH CSV DELIMITER '%s' ON SEGMENT %s;", tableName, columnNames, copyCommand, tableDelim, ignoreExternalPartitions)
+	query := fmt.Sprintf("COPY %s%s TO %s WITH CSV DELIMITER '%s' ON SEGMENT%s;", tableName, columnNames, copyCommand, tableDelim, ignoreExternalPartitions)
 	gplog.Verbose("Worker %d: %s", connNum, query)
 	result, err := connectionPool.Exec(query, connNum)
 	if err != nil {

--- a/backup/data.go
+++ b/backup/data.go
@@ -92,7 +92,9 @@ func CopyTableOut(connectionPool *dbconn.DBConn, table Table, destinationToWrite
 		columnNames = ConstructTableAttributesList(table.ColumnDefs)
 		tableName = fmt.Sprintf("(SELECT %s FROM %s %s)", columnNames[1:len(columnNames)-1], tableName, table.ExtensionTableConfig.Condition)
 		columnNames = ""
-		ignoreExternalPartitions = ""
+		if connectionPool.Version.Before("7") {
+			ignoreExternalPartitions = ""
+		}
 	}
 
 	query := fmt.Sprintf("COPY %s%s TO %s WITH CSV DELIMITER '%s' ON SEGMENT %s;", tableName, columnNames, copyCommand, tableDelim, ignoreExternalPartitions)

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -41,13 +41,14 @@ func SplitTablesByPartitionType(tables []Table, includeList []options.Relation) 
 		}
 
 		for _, table := range tables {
+			isExtensionTable := table.ExtensionTableConfig != (ExtensionTableConfig{})
 			if table.IsExternal && table.PartitionLevelInfo.Level == "l" {
 				if connectionPool.Version.Before("7") {
 					// GPDB7+ has different conventions for external partitions
 					// and does not need the suffix added
 					table.Name = AppendExtPartSuffix(table.Name)
 				}
-				if table.ExtensionTableConfig == (ExtensionTableConfig{}) {
+				if !isExtensionTable {
 					metadataTables = append(metadataTables, table)
 				}
 			}
@@ -55,11 +56,11 @@ func SplitTablesByPartitionType(tables []Table, includeList []options.Relation) 
 			if connectionPool.Version.AtLeast("7") {
 				// In GPDB 7+, we need to dump out the leaf partition DDL along with their
 				// ALTER TABLE ATTACH PARTITION commands to construct the partition table
-				if table.ExtensionTableConfig == (ExtensionTableConfig{}) {
+				if !isExtensionTable {
 					metadataTables = append(metadataTables, table)
 				}
 			} else if partType != "l" && partType != "i" {
-				if table.ExtensionTableConfig == (ExtensionTableConfig{}) {
+				if !isExtensionTable {
 					metadataTables = append(metadataTables, table)
 				}
 			}
@@ -100,7 +101,8 @@ func SplitTablesByPartitionType(tables []Table, includeList []options.Relation) 
 				table.Name = AppendExtPartSuffix(table.Name)
 			}
 
-			if table.ExtensionTableConfig == (ExtensionTableConfig{}) {
+			isExtensionTable := table.ExtensionTableConfig != (ExtensionTableConfig{})
+			if !isExtensionTable {
 				metadataTables = append(metadataTables, table)
 			}
 			// In GPDB 7+, we need to filter out leaf and intermediate subroot partitions

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -41,14 +41,13 @@ func SplitTablesByPartitionType(tables []Table, includeList []options.Relation) 
 		}
 
 		for _, table := range tables {
-			isExtensionTable := table.ExtensionTableConfig != (ExtensionTableConfig{})
 			if table.IsExternal && table.PartitionLevelInfo.Level == "l" {
 				if connectionPool.Version.Before("7") {
 					// GPDB7+ has different conventions for external partitions
 					// and does not need the suffix added
 					table.Name = AppendExtPartSuffix(table.Name)
 				}
-				if !isExtensionTable {
+				if table.ExtensionTableConfig == nil {
 					metadataTables = append(metadataTables, table)
 				}
 			}
@@ -56,11 +55,11 @@ func SplitTablesByPartitionType(tables []Table, includeList []options.Relation) 
 			if connectionPool.Version.AtLeast("7") {
 				// In GPDB 7+, we need to dump out the leaf partition DDL along with their
 				// ALTER TABLE ATTACH PARTITION commands to construct the partition table
-				if !isExtensionTable {
+				if table.ExtensionTableConfig == nil {
 					metadataTables = append(metadataTables, table)
 				}
 			} else if partType != "l" && partType != "i" {
-				if !isExtensionTable {
+				if table.ExtensionTableConfig == nil {
 					metadataTables = append(metadataTables, table)
 				}
 			}
@@ -101,8 +100,7 @@ func SplitTablesByPartitionType(tables []Table, includeList []options.Relation) 
 				table.Name = AppendExtPartSuffix(table.Name)
 			}
 
-			isExtensionTable := table.ExtensionTableConfig != (ExtensionTableConfig{})
-			if !isExtensionTable {
+			if table.ExtensionTableConfig == nil {
 				metadataTables = append(metadataTables, table)
 			}
 			// In GPDB 7+, we need to filter out leaf and intermediate subroot partitions

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -48,6 +48,8 @@ func SplitTablesByPartitionType(tables []Table, includeList []options.Relation) 
 					table.Name = AppendExtPartSuffix(table.Name)
 				}
 				if table.ExtensionTableConfig == nil {
+					// If the table is not a configuration table for the extension,
+					// then add it to the metadata.
 					metadataTables = append(metadataTables, table)
 				}
 			}
@@ -56,10 +58,14 @@ func SplitTablesByPartitionType(tables []Table, includeList []options.Relation) 
 				// In GPDB 7+, we need to dump out the leaf partition DDL along with their
 				// ALTER TABLE ATTACH PARTITION commands to construct the partition table
 				if table.ExtensionTableConfig == nil {
+					// If the table is not a configuration table for the extension,
+					// then add it to the metadata.
 					metadataTables = append(metadataTables, table)
 				}
 			} else if partType != "l" && partType != "i" {
 				if table.ExtensionTableConfig == nil {
+					// If the table is not a configuration table for the extension,
+					// then add it to the metadata.
 					metadataTables = append(metadataTables, table)
 				}
 			}
@@ -101,6 +107,8 @@ func SplitTablesByPartitionType(tables []Table, includeList []options.Relation) 
 			}
 
 			if table.ExtensionTableConfig == nil {
+				// If the table is not a configuration table for the extension,
+				// then add it to the metadata.
 				metadataTables = append(metadataTables, table)
 			}
 			// In GPDB 7+, we need to filter out leaf and intermediate subroot partitions

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -47,15 +47,21 @@ func SplitTablesByPartitionType(tables []Table, includeList []options.Relation) 
 					// and does not need the suffix added
 					table.Name = AppendExtPartSuffix(table.Name)
 				}
-				metadataTables = append(metadataTables, table)
+				if table.ExtensionTableConfig == (ExtensionTableConfig{}) {
+					metadataTables = append(metadataTables, table)
+				}
 			}
 			partType := table.PartitionLevelInfo.Level
 			if connectionPool.Version.AtLeast("7") {
 				// In GPDB 7+, we need to dump out the leaf partition DDL along with their
 				// ALTER TABLE ATTACH PARTITION commands to construct the partition table
-				metadataTables = append(metadataTables, table)
+				if table.ExtensionTableConfig == (ExtensionTableConfig{}) {
+					metadataTables = append(metadataTables, table)
+				}
 			} else if partType != "l" && partType != "i" {
-				metadataTables = append(metadataTables, table)
+				if table.ExtensionTableConfig == (ExtensionTableConfig{}) {
+					metadataTables = append(metadataTables, table)
+				}
 			}
 			if MustGetFlagBool(options.LEAF_PARTITION_DATA) {
 				if partType != "p" && partType != "i" {
@@ -94,7 +100,9 @@ func SplitTablesByPartitionType(tables []Table, includeList []options.Relation) 
 				table.Name = AppendExtPartSuffix(table.Name)
 			}
 
-			metadataTables = append(metadataTables, table)
+			if table.ExtensionTableConfig == (ExtensionTableConfig{}) {
+				metadataTables = append(metadataTables, table)
+			}
 			// In GPDB 7+, we need to filter out leaf and intermediate subroot partitions
 			// since the COPY will be called on the top-most root partition. It just so
 			// happens that those particular partition types will always have an

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -220,6 +220,26 @@ func GetForeignTableRelations(connectionPool *dbconn.DBConn) []Relation {
 	return results
 }
 
+func GetExtensionTableRelations(connectionPool *dbconn.DBConn) []Relation {
+	query := fmt.Sprintf(`
+	SELECT n.oid AS schemaoid,
+		c.oid AS oid,
+		quote_ident(n.nspname) AS schema,
+		quote_ident(c.relname) AS name
+	FROM pg_class c
+		JOIN pg_namespace n ON c.relnamespace = n.oid
+	WHERE %s
+		AND relkind IN ('r', 'p')
+		AND %s
+	ORDER BY c.oid`,
+		relationAndSchemaFilterClause(), ExtensionConfigClause("c"))
+
+	results := make([]Relation, 0)
+	err := connectionPool.Select(&results, query)
+	gplog.FatalOnError(err)
+	return results
+}
+
 type Sequence struct {
 	Relation
 	OwningTableOid          string

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -230,8 +230,7 @@ func GetExtensionTableRelations(connectionPool *dbconn.DBConn) []Relation {
 		JOIN pg_namespace n ON c.relnamespace = n.oid
 	WHERE %s
 		AND relkind IN ('r', 'p')
-		AND %s
-	ORDER BY c.oid`,
+		AND %s`,
 		relationAndSchemaFilterClause(), ExtensionConfigClause("c"))
 
 	results := make([]Relation, 0)

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -230,8 +230,8 @@ func GetExtensionTableRelations(connectionPool *dbconn.DBConn) []Relation {
 		JOIN pg_namespace n ON c.relnamespace = n.oid
 	WHERE %s
 		AND relkind IN ('r', 'p')
-		AND %s`,
-		relationAndSchemaFilterClause(), ExtensionConfigClause("c"))
+		AND c.oid IN (select unnest(extconfig) from pg_catalog.pg_extension)`,
+		relationAndSchemaFilterClause())
 
 	results := make([]Relation, 0)
 	err := connectionPool.Select(&results, query)

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -223,7 +223,7 @@ func GetForeignTableRelations(connectionPool *dbconn.DBConn) []Relation {
 func GetExtensionTableRelations(connectionPool *dbconn.DBConn) []Relation {
 	query := fmt.Sprintf(`
 	SELECT n.oid AS schemaoid,
-		c.oid AS oid,
+		c.oid,
 		quote_ident(n.nspname) AS schema,
 		quote_ident(c.relname) AS name
 	FROM pg_class c

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -333,15 +333,6 @@ func ExtensionFilterClause(namespace string) string {
 	return fmt.Sprintf("%s NOT IN (select objid from pg_depend where deptype = 'e')", oidStr)
 }
 
-func ExtensionConfigClause(namespace string) string {
-	oidStr := "oid"
-	if namespace != "" {
-		oidStr = fmt.Sprintf("%s.oid", namespace)
-	}
-
-	return fmt.Sprintf("%s IN (select unnest(extconfig) from pg_catalog.pg_extension)", oidStr)
-}
-
 type AccessMethod struct {
 	Oid     uint32
 	Name    string

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -333,6 +333,15 @@ func ExtensionFilterClause(namespace string) string {
 	return fmt.Sprintf("%s NOT IN (select objid from pg_depend where deptype = 'e')", oidStr)
 }
 
+func ExtensionConfigClause(namespace string) string {
+	oidStr := "oid"
+	if namespace != "" {
+		oidStr = fmt.Sprintf("%s.oid", namespace)
+	}
+
+	return fmt.Sprintf("%s IN (select unnest(extconfig) from pg_catalog.pg_extension)", oidStr)
+}
+
 type AccessMethod struct {
 	Oid     uint32
 	Name    string

--- a/backup/queries_table_defs.go
+++ b/backup/queries_table_defs.go
@@ -81,7 +81,7 @@ type TableDefinition struct {
 	PartitionKeyDef         string
 	AttachPartitionInfo     AttachPartitionInfo
 	ForceRowSecurity        bool
-	ExtensionTableConfig    ExtensionTableConfig
+	ExtensionTableConfig    *string
 }
 
 /*
@@ -792,7 +792,7 @@ type ExtensionTableConfig struct {
 	Condition string
 }
 
-func GetExtensionTableConfigs(connectionPool *dbconn.DBConn) map[uint32]ExtensionTableConfig {
+func GetExtensionTableConfigs(connectionPool *dbconn.DBConn) map[uint32]*string {
 	gplog.Verbose("Retrieving extension table information")
 
 	query := "SELECT unnest(extconfig) oid, unnest(extcondition) condition FROM pg_catalog.pg_extension"
@@ -800,9 +800,10 @@ func GetExtensionTableConfigs(connectionPool *dbconn.DBConn) map[uint32]Extensio
 	results := make([]ExtensionTableConfig, 0)
 	err := connectionPool.Select(&results, query)
 	gplog.FatalOnError(err)
-	resultMap := make(map[uint32]ExtensionTableConfig)
+	resultMap := make(map[uint32]*string)
 	for _, result := range results {
-		resultMap[result.Oid] = result
+		condition := strings.Clone(result.Condition)
+		resultMap[result.Oid] = &condition
 	}
 	return resultMap
 }

--- a/backup/queries_table_defs.go
+++ b/backup/queries_table_defs.go
@@ -794,11 +794,8 @@ type ExtensionTableConfig struct {
 
 func GetExtensionTableConfigs(connectionPool *dbconn.DBConn) map[uint32]*string {
 	gplog.Verbose("Retrieving extension table information")
-
-	query := "SELECT unnest(extconfig) oid, unnest(extcondition) condition FROM pg_catalog.pg_extension"
-
 	results := make([]ExtensionTableConfig, 0)
-	err := connectionPool.Select(&results, query)
+	err := connectionPool.Select(&results, "SELECT unnest(extconfig) oid, unnest(extcondition) condition FROM pg_catalog.pg_extension")
 	gplog.FatalOnError(err)
 	resultMap := make(map[uint32]*string)
 	for _, result := range results {

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -214,6 +214,7 @@ func RetrieveAndProcessTables() ([]Table, []Table, []Table) {
 	if connectionPool.Version.AtLeast("6") {
 		tableRelations = append(tableRelations, GetForeignTableRelations(connectionPool)...)
 	}
+	tableRelations = append(tableRelations, GetExtensionTableRelations(connectionPool)...)
 
 	allTables := ConstructDefinitionsForTables(connectionPool, tableRelations)
 

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1165,6 +1165,10 @@ var _ = Describe("backup and restore end to end tests", func() {
 			gprestore(gprestorePath, restoreHelperPath, timestamp,
 				"--redirect-db", "restoredb")
 
+			assertDataRestored(restoreConn, map[string]int{
+				"public.test1": 100,
+				"public.test2": 50,
+			})
 			assertArtifactsCleaned(restoreConn, timestamp)
 		})
 	})

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1150,6 +1150,8 @@ var _ = Describe("backup and restore end to end tests", func() {
 				CREATE EXTENSION test_ext2;
 				CREATE EXTENSION test_ext4;
 				CREATE EXTENSION test_ext1;
+				INSERT INTO test1 SELECT i FROM generate_series(1, 100) i;
+				INSERT INTO test2 SELECT i, i % 2 != 0 FROM generate_series(1, 100) i;
 			`)
 			defer testhelper.AssertQueryRuns(backupConn, `
 				DROP EXTENSION test_ext1;
@@ -1159,8 +1161,7 @@ var _ = Describe("backup and restore end to end tests", func() {
 				DROP EXTENSION test_ext3;
 			`)
 
-			timestamp := gpbackup(gpbackupPath, backupHelperPath,
-				"--metadata-only")
+			timestamp := gpbackup(gpbackupPath, backupHelperPath)
 			gprestore(gprestorePath, restoreHelperPath, timestamp,
 				"--redirect-db", "restoredb")
 

--- a/end_to_end/resources/test_ext1--1.0.sql
+++ b/end_to_end/resources/test_ext1--1.0.sql
@@ -1,3 +1,8 @@
 /* src/test/modules/test_extensions/test_ext1--1.0.sql */
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION test_ext1" to load this file. \quit
+
+CREATE TABLE test1 (i int) distributed by (i);
+CREATE TABLE test2 (i int, b bool) distributed by (i);
+SELECT pg_catalog.pg_extension_config_dump('test1', '');
+SELECT pg_catalog.pg_extension_config_dump('test2', 'WHERE b');

--- a/end_to_end/resources/test_ext1--1.0.sql
+++ b/end_to_end/resources/test_ext1--1.0.sql
@@ -2,7 +2,7 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION test_ext1" to load this file. \quit
 
-CREATE TABLE test1 (i int) distributed by (i);
-CREATE TABLE test2 (i int, b bool) distributed by (i);
+CREATE TABLE test1 (i int) DISTRIBUTED BY (i);
+CREATE TABLE test2 (i int, b bool) DISTRIBUTED BY (i);
 SELECT pg_catalog.pg_extension_config_dump('test1', '');
 SELECT pg_catalog.pg_extension_config_dump('test2', 'WHERE b');


### PR DESCRIPTION
Make it possible to backup/restore extension configuration tables.

This patch adds support for extension configuration tables to gpbackup. The
extension script can specify tables that need to be backuped/restored using the
standard function pg_catalog.pg_extension_config_dump. As a result, gpbackup
will include the data of the specified tables (but not their definition) in the
backup. If the second argument to the pg_catalog.pg_extension_config_dump
function is an empty string, then gpbackup will dump the entire contents of the
table. A non-empty string in the second argument of the
pg_catalog.pg_extension_config_dump function means a WHERE clause that filters
out the data to be dumped. gpdb versions earlier than 7 do not support the
IGNORE EXTERNAL PARTITIONS option for the COPY ( query ) TO command, so this
option is omitted if an additional filter is present.