### PR TITLE
ADBDEV-5321: Fix gprestore hang on errors with on-error-continue option when resize-restore

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -2273,6 +2273,21 @@ LANGUAGE plpgsql NO SQL;`)
 			assertArtifactsCleaned(restoreConn, "20240301124333")
 			testhelper.AssertQueryRuns(restoreConn, "DROP TABLE test;")
 		})
+		It("Will not hang after error during restore", func() {
+			command := exec.Command("tar", "-xzf", "resources/2-segment-db-error.tar.gz", "-C", backupDir)
+			mustRunCommand(command)
+			gprestoreCmd := exec.Command(gprestorePath,
+				"--timestamp", "20240502095933",
+				"--redirect-db", "restoredb",
+				"--backup-dir", path.Join(backupDir, "2-segment-db-error"),
+				"--resize-cluster", "--on-error-continue")
+			output, err := gprestoreCmd.CombinedOutput()
+			Expect(err).To(HaveOccurred())
+			Expect(string(output)).To(ContainSubstring(`Error loading data into table public.t1`))
+			Expect(string(output)).To(ContainSubstring(`Error loading data into table public.t3`))
+			assertArtifactsCleaned(restoreConn, "20240502095933")
+			testhelper.AssertQueryRuns(restoreConn, "DROP TABLE t0; DROP TABLE t1; DROP TABLE t2; DROP TABLE t3; DROP TABLE t4;")
+		})
 	})
 	Describe("Restore indexes and constraints on exchanged partition tables", func() {
 		BeforeEach(func() {

--- a/restore/data.go
+++ b/restore/data.go
@@ -266,7 +266,7 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Co
 					mutex.Unlock()
 				}
 
-				if backupConfig.SingleDataFile {
+				if backupConfig.SingleDataFile || MustGetFlagBool(options.RESIZE_CLUSTER) {
 					agentErr := utils.CheckAgentErrorsOnSegments(globalCluster, globalFPInfo)
 					if agentErr != nil {
 						gplog.Error(agentErr.Error())

--- a/restore/data.go
+++ b/restore/data.go
@@ -257,7 +257,7 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Co
 					if !MustGetFlagBool(options.ON_ERROR_CONTINUE) {
 						dataProgressBar.(*pb.ProgressBar).NotPrint = true
 						return
-					} else if connectionPool.Version.AtLeast("6") && backupConfig.SingleDataFile {
+					} else if connectionPool.Version.AtLeast("6") && (backupConfig.SingleDataFile || MustGetFlagBool(options.RESIZE_CLUSTER)) {
 						// inform segment helpers to skip this entry
 						utils.CreateSkipFileOnSegments(fmt.Sprintf("%d", entry.Oid), tableName, globalCluster, globalFPInfo)
 					}


### PR DESCRIPTION
Fix gprestore hang on errors with on-error-continue option when resize-restore

gprestore did not correctly handle the on-error-continue option when
resize-restore. Errors during restore could cause restore helpers to freeze.

This patch adds the creation of skip files in case of errors, as well as error
checking on segments during resize-restore, as is already done with
single-data-file.