### PR TITLE
fix dependency handling for functions

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -242,20 +242,18 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 
 	var protocols []ExternalProtocol
 	var functions []Function
-	var dependentFunctions []Function
 	var funcInfoMap map[uint32]FunctionInfo
 	objects := make([]Sortable, 0)
 	metadataMap := make(MetadataMap)
 
 	if !tableOnly {
-		functions, dependentFunctions, funcInfoMap = retrieveFunctions(&objects, metadataMap)
+		functions, funcInfoMap = retrieveFunctions(&objects, metadataMap)
 	}
 	objects = append(objects, convertToSortableSlice(tables)...)
 	relationMetadata := GetMetadataForObjectType(connectionPool, TYPE_RELATION)
 	addToMetadataMap(relationMetadata, metadataMap)
 
 	if !tableOnly {
-		objects = append(objects, convertToSortableSlice(dependentFunctions)...)
 		protocols = retrieveProtocols(&objects, metadataMap)
 		backupSchemas(metadataFile, createAlteredPartitionSchemaSet(tables))
 		backupExtensions(metadataFile)

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -278,12 +278,13 @@ func GetDependencies(connectionPool *dbconn.DBConn, backupSet map[UniqueID]bool,
 	query := `SELECT
 	coalesce(id1.refclassid, d.classid) AS classid,
 	coalesce(id1.refobjid, d.objid) AS objid,
-	coalesce(id2.refclassid, d.refclassid) AS refclassid,
-	coalesce(id2.refobjid, d.refobjid) AS refobjid
+	coalesce(id3.refclassid, id2.refclassid, d.refclassid) AS refclassid,
+	coalesce(id3.refobjid, id2.refobjid, d.refobjid) AS refobjid
 FROM pg_depend d
 -- link implicit objects, using objid and refobjid, to the objects that created them
 LEFT JOIN pg_depend id1 ON (d.objid = id1.objid and d.classid = id1.classid and id1.deptype='i')
 LEFT JOIN pg_depend id2 ON (d.refobjid = id2.objid and d.refclassid = id2.classid and id2.deptype='i')
+LEFT JOIN pg_depend id3 ON (id2.refobjid = id3.objid and id2.refclassid = id3.classid and id3.deptype='i')
 WHERE d.classid != 0
 AND d.deptype != 'i'
 UNION

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -181,6 +181,7 @@ func GetFunctions(connectionPool *dbconn.DBConn) []Function {
 			prokind,
 			prosupport,
 			l.lanname AS language,
+			%s
             coalesce(array_to_string(ARRAY(SELECT 'FOR TYPE ' || nm.nspname || '.' || typ.typname
                 from
                     unnest(p.protrftypes) as trf_unnest
@@ -188,9 +189,8 @@ func GetFunctions(connectionPool *dbconn.DBConn) []Function {
                          on trf_unnest = typ.oid
 					left join pg_namespace nm
 						on typ.typnamespace = nm.oid
-                ), ', '), '') AS transformtypes,
-			%s
-				FROM pg_proc p
+                ), ', '), '') AS transformtypes
+		FROM pg_proc p
 			JOIN pg_catalog.pg_language l ON p.prolang = l.oid
 			LEFT JOIN pg_namespace n ON p.pronamespace = n.oid
 		WHERE %s

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -224,25 +224,16 @@ func RetrieveAndProcessTables() ([]Table, []Table, []Table) {
 	return metadataTables, dataTables, allTables
 }
 
-func retrieveFunctions(sortables *[]Sortable, metadataMap MetadataMap) ([]Function, []Function, map[uint32]FunctionInfo) {
+func retrieveFunctions(sortables *[]Sortable, metadataMap MetadataMap) ([]Function, map[uint32]FunctionInfo) {
 	gplog.Verbose("Retrieving function information")
 	functionMetadata := GetMetadataForObjectType(connectionPool, TYPE_FUNCTION)
 	addToMetadataMap(functionMetadata, metadataMap)
 	functions := GetFunctionsAllVersions(connectionPool)
 	funcInfoMap := GetFunctionOidToInfoMap(connectionPool)
 	objectCounts["Functions"] = len(functions)
-	independentFunctions := make([]Function, 0)
-	dependentFunctions := make([]Function, 0)
-	for _, function := range functions {
-		if function.IsDependOnTables {
-			dependentFunctions = append(dependentFunctions, function)
-		} else {
-			independentFunctions = append(independentFunctions, function)
-		}
-	}
-	*sortables = append(*sortables, convertToSortableSlice(independentFunctions)...)
+	*sortables = append(*sortables, convertToSortableSlice(functions)...)
 
-	return functions, dependentFunctions, funcInfoMap
+	return functions, funcInfoMap
 }
 
 func retrieveTransforms(sortables *[]Sortable) {

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1892,31 +1892,6 @@ LANGUAGE plpgsql NO SQL;`)
 
 				assertArtifactsCleaned(restoreConn, timestamp)
 			})
-			It("runs gpbackup and gprestore to backup functions depending on table row's type", func() {
-				skipIfOldBackupVersionBefore("1.19.0")
-
-				testhelper.AssertQueryRuns(backupConn, "CREATE TABLE table_provides_type (n int);")
-				defer testhelper.AssertQueryRuns(backupConn, "DROP TABLE table_provides_type;")
-
-				testhelper.AssertQueryRuns(backupConn, "INSERT INTO table_provides_type values (1);")
-				testhelper.AssertQueryRuns(backupConn, "CREATE OR REPLACE FUNCTION func_depends_on_row_type(arg table_provides_type[]) RETURNS void AS $$ BEGIN; SELECT NULL; END; $$ LANGUAGE SQL;")
-
-				defer testhelper.AssertQueryRuns(backupConn, "DROP FUNCTION func_depends_on_row_type(arg table_provides_type[]);")
-
-				timestamp := gpbackup(gpbackupPath, backupHelperPath)
-				gprestore(gprestorePath, restoreHelperPath, timestamp,
-					"--redirect-db", "restoredb")
-
-				assertRelationsCreated(restoreConn, TOTAL_RELATIONS+1) // for 1 new table
-				assertDataRestored(restoreConn, schema2TupleCounts)
-				assertDataRestored(restoreConn, map[string]int{
-					"public.foo":                 40000,
-					"public.holds":               50000,
-					"public.sales":               13,
-					"public.table_provides_type": 1})
-
-				assertArtifactsCleaned(restoreConn, timestamp)
-			})
 			It("Can restore xml with xmloption set to document", func() {
 				testutils.SkipIfBefore6(backupConn)
 				// Set up the XML table that contains XML content


### PR DESCRIPTION
there are complex logic to handle object dependencies in GetDependencies
function. This logic starts from non-internal dependencies (e.g. with
namespaces) and enrich them by up to two levels of internal dependencies.
E.g. some function depends on composite type and this type depends
on a user table. But sometimes it's not enough, e.g. in case of
function argument is an array of user composite types. In this case
dependency chain is function-array_of_type-type-relation:

```
 classid  |     objid      |  refclassid  |   refobjid   | deptype
----------+----------------+--------------+--------------+---------
 pg_type  | some_table     | pg_class     | some_table   | i
 pg_type  | some_table[]   | pg_type      | some_table   | i
 pg_class | some_table     | pg_namespace | public       | n
 pg_proc  | dependant_func | pg_namespace | public       | n
 pg_proc  | dependant_func | pg_type      | some_table[] | n
```

This patch append handling for one more dependency level. I've
intentionally avoided recursive queries here because there are problems
with recursive query support in the old gpdb versions. This code part
has branches even for gpdb 4. Also, I couldn't reproduce longer chain of
internal dependencies.

The previous approaches (#57) has banch of issues:
* poor performance that caused by EXIST clause that can't be rewritten to 
  semi-join by planners (26+ hours for the prod schema)
* relying on object order in list without fixing dependency handling

The high-level e2e test was replaced with more precise integration test

The patch must be merged by rebase as two separate commits.