### PR TITLE
Fix restoring with subset and --on-error-continue together

### DIFF
--- a/helper/helper_suite_test.go
+++ b/helper/helper_suite_test.go
@@ -1,0 +1,13 @@
+package helper_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHelper(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Helper Suite")
+}

--- a/helper/helper_test.go
+++ b/helper/helper_test.go
@@ -1,0 +1,101 @@
+package helper
+
+import (
+	"github.com/greenplum-db/gpbackup/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("helper tests", func() {
+	var pluginConfig utils.PluginConfig
+	var isSubset bool
+	var fileToRead, fileGzToRead, fileZstdToRead string
+
+	InitializeGlobals()
+
+	*isFiltered = true
+	fileToRead = "/tmp/file"
+	fileGzToRead = "/tmp/file.gz"
+	fileZstdToRead = "/tmp/file.zst"
+	pluginConfig = utils.PluginConfig{
+		ExecutablePath: "/a/b/myPlugin",
+		ConfigPath:     "/tmp/my_plugin_config.yaml",
+		Options:        make(map[string]string),
+	}
+
+	Describe("Check subset flag", func() {
+		It("when restore_subset is off, --on-error-continue is false, compression is not used", func() {
+			pluginConfig.Options["restore_subset"] = "off"
+			*onErrorContinue = false
+			isSubset = getSubsetFlag(fileToRead, &pluginConfig)
+			Expect(isSubset).To(Equal(false))
+		})
+		It("when restore_subset is on, --on-error-continue is false, compression is not used", func() {
+			pluginConfig.Options["restore_subset"] = "on"
+			*onErrorContinue = false
+			isSubset = getSubsetFlag(fileToRead, &pluginConfig)
+			Expect(isSubset).To(Equal(true))
+		})
+		It("when restore_subset is off, --on-error-continue is true, compression is not used", func() {
+			pluginConfig.Options["restore_subset"] = "off"
+			*onErrorContinue = true
+			isSubset = getSubsetFlag(fileToRead, &pluginConfig)
+			Expect(isSubset).To(Equal(false))
+		})
+		It("when restore_subset is on, --on-error-continue is true, compression is not used", func() {
+			pluginConfig.Options["restore_subset"] = "on"
+			*onErrorContinue = true
+			isSubset = getSubsetFlag(fileToRead, &pluginConfig)
+			Expect(isSubset).To(Equal(false))
+		})
+		It("when restore_subset is off, --on-error-continue is false, compression \"gz\" is used", func() {
+			pluginConfig.Options["restore_subset"] = "off"
+			*onErrorContinue = false
+			isSubset = getSubsetFlag(fileGzToRead, &pluginConfig)
+			Expect(isSubset).To(Equal(false))
+		})
+		It("when restore_subset is on, --on-error-continue is false, compression \"gz\" is used", func() {
+			pluginConfig.Options["restore_subset"] = "on"
+			*onErrorContinue = false
+			isSubset = getSubsetFlag(fileGzToRead, &pluginConfig)
+			Expect(isSubset).To(Equal(false))
+		})
+		It("when restore_subset is off, --on-error-continue is true, compression \"gz\" is used", func() {
+			pluginConfig.Options["restore_subset"] = "off"
+			*onErrorContinue = true
+			isSubset = getSubsetFlag(fileGzToRead, &pluginConfig)
+			Expect(isSubset).To(Equal(false))
+		})
+		It("when restore_subset is on, --on-error-continue is true, compression \"gz\" is used", func() {
+			pluginConfig.Options["restore_subset"] = "on"
+			*onErrorContinue = true
+			isSubset = getSubsetFlag(fileGzToRead, &pluginConfig)
+			Expect(isSubset).To(Equal(false))
+		})
+		It("when restore_subset is off, --on-error-continue is false, compression \"zstd\" is used", func() {
+			pluginConfig.Options["restore_subset"] = "off"
+			*onErrorContinue = false
+			isSubset = getSubsetFlag(fileZstdToRead, &pluginConfig)
+			Expect(isSubset).To(Equal(false))
+		})
+		It("when restore_subset is on, --on-error-continue is false, compression \"zstd\" is used", func() {
+			pluginConfig.Options["restore_subset"] = "on"
+			*onErrorContinue = false
+			isSubset = getSubsetFlag(fileZstdToRead, &pluginConfig)
+			Expect(isSubset).To(Equal(false))
+		})
+		It("when restore_subset is off, --on-error-continue is true, compression \"zstd\" is used", func() {
+			pluginConfig.Options["restore_subset"] = "off"
+			*onErrorContinue = true
+			isSubset = getSubsetFlag(fileZstdToRead, &pluginConfig)
+			Expect(isSubset).To(Equal(false))
+		})
+		It("when restore_subset is on, --on-error-continue is true, compression \"zstd\" is used", func() {
+			pluginConfig.Options["restore_subset"] = "on"
+			*onErrorContinue = true
+			isSubset = getSubsetFlag(fileZstdToRead, &pluginConfig)
+			Expect(isSubset).To(Equal(false))
+		})
+	})
+})


### PR DESCRIPTION
```
Fix restoring with subset and --on-error-continue together

Subset restore API is incompatibilite with enabled "--on-error-continue" flag.
When some error is occured at reading data from file, plugin does not know about
such error and continues sending data to the pipe. It leads to situation:
gprestore breaks reading data of the current relation (for example because
relation does not exist) and starts reading data of the next relation (because
option --on-error-continue is set), but plugin sends data of non-existing
relation.

This patch disables subsets, if the "--on-error-continue" option is set. Also
unit tests were added for function, which checks whether subsets using is
allowed.


Co-authored-by: Dennis Kovalenko <kds@arenadata.io>
```