### PR TITLE
ADBDEV-5594: Do not batch replicated tables

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -2195,6 +2195,9 @@ LANGUAGE plpgsql NO SQL;`)
 					numSegments := dbconn.MustSelectString(restoreConn, "SELECT numsegments FROM gp_distribution_policy where localoid = 'schemaone.test_table'::regclass::oid")
 					Expect(numSegments).To(Equal(strconv.Itoa(segmentCount)))
 
+					// check there is no pipe errors on segments
+					errSegments := dbconn.MustSelectString(restoreConn, "SELECT exists (SELECT * FROM gp_toolkit.__gp_log_segment_ext WHERE logtime > now() - '1 min'::interval AND logmessage LIKE 'read err msg from pipe%No such file or directory%' ORDER BY logtime DESC)")
+					Expect(errSegments).To(Equal("false"))
 				},
 				Entry("Can backup a 1-segment cluster and restore to current cluster with replicated tables", "20221104023842", "1-segment-db-replicated"),
 				Entry("Can backup a 3-segment cluster and restore to current cluster with replicated tables", "20221104023611", "3-segment-db-replicated"),

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -2196,7 +2196,7 @@ LANGUAGE plpgsql NO SQL;`)
 					Expect(numSegments).To(Equal(strconv.Itoa(segmentCount)))
 
 					// check there is no pipe errors on segments
-					errSegments := dbconn.MustSelectString(restoreConn, "SELECT exists (SELECT * FROM gp_toolkit.__gp_log_segment_ext WHERE logtime > now() - '1 min'::interval AND logmessage LIKE 'read err msg from pipe%No such file or directory%' ORDER BY logtime DESC)")
+					errSegments := dbconn.MustSelectString(restoreConn, fmt.Sprintf("SELECT exists (SELECT * FROM gp_toolkit.__gp_log_segment_ext WHERE logdatabase = current_database() AND logmessage LIKE 'read err msg from pipe%%_%06d_%%')", gprestoreCmd.Process.Pid))
 					Expect(errSegments).To(Equal("false"))
 				},
 				Entry("Can backup a 1-segment cluster and restore to current cluster with replicated tables", "20221104023842", "1-segment-db-replicated"),

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -119,6 +119,105 @@ var _ = Describe("restore/data tests", func() {
 				"ERROR: value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1 (SQLSTATE 22P04)"))
 		})
 	})
+	Describe("CopyTableIn with resize restore from 4 to 3 segments", func() {
+		BeforeEach(func() {
+			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "cat", OutputCommand: "cat -", InputCommand: "cat -", Extension: ""})
+			backup.SetPluginConfig(nil)
+			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "")
+			_ = cmdFlags.Set(options.RESIZE_CLUSTER, "true")
+			backup.SetCluster(&cluster.Cluster{ContentIDs: []int{-1, 0, 1, 2, 3}})
+			restore.SetBackupConfig(&history.BackupConfig{})
+		})
+		It("will restore a table from its own file with gzip compression", func() {
+			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "gzip", OutputCommand: "gzip -c -1", InputCommand: "gzip -d -c", Extension: ".gz"})
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz"
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from its own file with zstd compression", func() {
+			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "zstd", OutputCommand: "zstd --compress -1 -c", InputCommand: "zstd --decompress -c", Extension: ".zst"})
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst"
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from its own file without compression", func() {
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from a single data file", func() {
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456"
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, true, 0, false)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from its own file with gzip compression using a plugin", func() {
+			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "gzip", OutputCommand: "gzip -c -1", InputCommand: "gzip -d -c", Extension: ".gz"})
+			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "/tmp/plugin_config")
+			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
+			restore.SetPluginConfig(&pluginConfig)
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from its own file with zstd compression using a plugin", func() {
+			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "zstd", OutputCommand: "zstd --compress -1 -c", InputCommand: "zstd --decompress -c", Extension: ".zst"})
+			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "/tmp/plugin_config")
+			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
+			restore.SetPluginConfig(&pluginConfig)
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst"
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from its own file without compression using a plugin", func() {
+			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "/tmp/plugin_config")
+			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
+			restore.SetPluginConfig(&pluginConfig)
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will output expected error string from COPY ON SEGMENT failure", func() {
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
+			pgErr := &pgconn.PgError{
+				Severity: "ERROR",
+				Code:     "22P04",
+				Message:  "value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1",
+				Where:    "COPY foo, line 1: \"5\"",
+			}
+			mock.ExpectExec(execStr).WillReturnError(pgErr)
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Error loading data into table public.foo: " +
+				"COPY foo, line 1: \"5\": " +
+				"ERROR: value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1 (SQLSTATE 22P04)"))
+		})
+	})
 	Describe("CheckRowsRestored", func() {
 		var (
 			expectedRows int64 = 10

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -225,6 +225,105 @@ var _ = Describe("restore/data tests", func() {
 				"ERROR: value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1 (SQLSTATE 22P04)"))
 		})
 	})
+	Describe("CopyTableIn with resize restore from 4 to 3 segments and replicated table", func() {
+		BeforeEach(func() {
+			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "cat", OutputCommand: "cat -", InputCommand: "cat -", Extension: ""})
+			backup.SetPluginConfig(nil)
+			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "")
+			_ = cmdFlags.Set(options.RESIZE_CLUSTER, "true")
+			backup.SetCluster(&cluster.Cluster{ContentIDs: []int{-1, 0, 1, 2}})
+			restore.SetBackupConfig(&history.BackupConfig{SegmentCount: 4})
+		})
+		It("will restore a table from its own file with gzip compression", func() {
+			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "gzip", OutputCommand: "gzip -c -1", InputCommand: "gzip -d -c", Extension: ".gz"})
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz"
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from its own file with zstd compression", func() {
+			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "zstd", OutputCommand: "zstd --compress -1 -c", InputCommand: "zstd --decompress -c", Extension: ".zst"})
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst"
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from its own file without compression", func() {
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from a single data file", func() {
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456"
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, true, 0, true)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from its own file with gzip compression using a plugin", func() {
+			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "gzip", OutputCommand: "gzip -c -1", InputCommand: "gzip -d -c", Extension: ".gz"})
+			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "/tmp/plugin_config")
+			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
+			restore.SetPluginConfig(&pluginConfig)
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from its own file with zstd compression using a plugin", func() {
+			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "zstd", OutputCommand: "zstd --compress -1 -c", InputCommand: "zstd --decompress -c", Extension: ".zst"})
+			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "/tmp/plugin_config")
+			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
+			restore.SetPluginConfig(&pluginConfig)
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst"
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from its own file without compression using a plugin", func() {
+			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "/tmp/plugin_config")
+			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
+			restore.SetPluginConfig(&pluginConfig)
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will output expected error string from COPY ON SEGMENT failure", func() {
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
+			pgErr := &pgconn.PgError{
+				Severity: "ERROR",
+				Code:     "22P04",
+				Message:  "value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1",
+				Where:    "COPY foo, line 1: \"5\"",
+			}
+			mock.ExpectExec(execStr).WillReturnError(pgErr)
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Error loading data into table public.foo: " +
+				"COPY foo, line 1: \"5\": " +
+				"ERROR: value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1 (SQLSTATE 22P04)"))
+		})
+	})
 	Describe("CheckRowsRestored", func() {
 		var (
 			expectedRows int64 = 10

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -131,40 +131,44 @@ var _ = Describe("restore/data tests", func() {
 		It("will restore a table from its own file with gzip compression", func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "gzip", OutputCommand: "gzip -c -1", InputCommand: "gzip -d -c", Extension: ".gz"})
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
+			numRowsRestored, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
 
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(numRowsRestored).Should(Equal(int64(20)))
 		})
 		It("will restore a table from its own file with zstd compression", func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "zstd", OutputCommand: "zstd --compress -1 -c", InputCommand: "zstd --decompress -c", Extension: ".zst"})
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
+			numRowsRestored, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
 
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(numRowsRestored).Should(Equal(int64(20)))
 		})
 		It("will restore a table from its own file without compression", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
+			numRowsRestored, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
 
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(numRowsRestored).Should(Equal(int64(20)))
 		})
 		It("will restore a table from a single data file", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, true, 0, false)
+			numRowsRestored, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, true, 0, false)
 
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(numRowsRestored).Should(Equal(int64(20)))
 		})
 		It("will restore a table from its own file with gzip compression using a plugin", func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "gzip", OutputCommand: "gzip -c -1", InputCommand: "gzip -d -c", Extension: ".gz"})
@@ -172,13 +176,14 @@ var _ = Describe("restore/data tests", func() {
 			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
 			restore.SetPluginConfig(&pluginConfig)
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
+			numRowsRestored, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
 
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(numRowsRestored).Should(Equal(int64(20)))
 		})
 		It("will restore a table from its own file with zstd compression using a plugin", func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "zstd", OutputCommand: "zstd --compress -1 -c", InputCommand: "zstd --decompress -c", Extension: ".zst"})
@@ -186,26 +191,28 @@ var _ = Describe("restore/data tests", func() {
 			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
 			restore.SetPluginConfig(&pluginConfig)
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
+			numRowsRestored, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
 
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(numRowsRestored).Should(Equal(int64(20)))
 		})
 		It("will restore a table from its own file without compression using a plugin", func() {
 			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "/tmp/plugin_config")
 			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
 			restore.SetPluginConfig(&pluginConfig)
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
+			numRowsRestored, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
 
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(numRowsRestored).Should(Equal(int64(20)))
 		})
 		It("will output expected error string from COPY ON SEGMENT failure", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
@@ -217,12 +224,13 @@ var _ = Describe("restore/data tests", func() {
 			}
 			mock.ExpectExec(execStr).WillReturnError(pgErr)
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
+			numRowsRestored, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("Error loading data into table public.foo: " +
 				"COPY foo, line 1: \"5\": " +
 				"ERROR: value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1 (SQLSTATE 22P04)"))
+			Expect(numRowsRestored).Should(Equal(int64(0)))
 		})
 	})
 	Describe("CopyTableIn with resize restore from 4 to 3 segments and replicated table", func() {
@@ -237,36 +245,40 @@ var _ = Describe("restore/data tests", func() {
 		It("will restore a table from its own file with gzip compression", func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "gzip", OutputCommand: "gzip -c -1", InputCommand: "gzip -d -c", Extension: ".gz"})
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
+			numRowsRestored, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
 
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(numRowsRestored).Should(Equal(int64(10)))
 		})
 		It("will restore a table from its own file with zstd compression", func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "zstd", OutputCommand: "zstd --compress -1 -c", InputCommand: "zstd --decompress -c", Extension: ".zst"})
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
+			numRowsRestored, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
 
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(numRowsRestored).Should(Equal(int64(10)))
 		})
 		It("will restore a table from its own file without compression", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
+			numRowsRestored, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
 
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(numRowsRestored).Should(Equal(int64(10)))
 		})
 		It("will restore a table from a single data file", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, true, 0, true)
+			numRowsRestored, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, true, 0, true)
 
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(numRowsRestored).Should(Equal(int64(10)))
 		})
 		It("will restore a table from its own file with gzip compression using a plugin", func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "gzip", OutputCommand: "gzip -c -1", InputCommand: "gzip -d -c", Extension: ".gz"})
@@ -274,12 +286,13 @@ var _ = Describe("restore/data tests", func() {
 			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
 			restore.SetPluginConfig(&pluginConfig)
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
+			numRowsRestored, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
 
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(numRowsRestored).Should(Equal(int64(10)))
 		})
 		It("will restore a table from its own file with zstd compression using a plugin", func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "zstd", OutputCommand: "zstd --compress -1 -c", InputCommand: "zstd --decompress -c", Extension: ".zst"})
@@ -287,24 +300,26 @@ var _ = Describe("restore/data tests", func() {
 			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
 			restore.SetPluginConfig(&pluginConfig)
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
+			numRowsRestored, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
 
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(numRowsRestored).Should(Equal(int64(10)))
 		})
 		It("will restore a table from its own file without compression using a plugin", func() {
 			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "/tmp/plugin_config")
 			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
 			restore.SetPluginConfig(&pluginConfig)
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
-			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 10))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
+			numRowsRestored, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
 
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(numRowsRestored).Should(Equal(int64(10)))
 		})
 		It("will output expected error string from COPY ON SEGMENT failure", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
@@ -316,12 +331,13 @@ var _ = Describe("restore/data tests", func() {
 			}
 			mock.ExpectExec(execStr).WillReturnError(pgErr)
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
+			numRowsRestored, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, true)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("Error loading data into table public.foo: " +
 				"COPY foo, line 1: \"5\": " +
 				"ERROR: value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1 (SQLSTATE 22P04)"))
+			Expect(numRowsRestored).Should(Equal(int64(0)))
 		})
 	})
 	Describe("CheckRowsRestored", func() {

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -34,7 +34,7 @@ var _ = Describe("restore/data tests", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz | gzip -d -c' WITH CSV DELIMITER ',' ON SEGMENT")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -43,7 +43,7 @@ var _ = Describe("restore/data tests", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst | zstd --decompress -c' WITH CSV DELIMITER ',' ON SEGMENT")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -51,7 +51,7 @@ var _ = Describe("restore/data tests", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -59,7 +59,7 @@ var _ = Describe("restore/data tests", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, true, 0)
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, true, 0, false)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -72,7 +72,7 @@ var _ = Describe("restore/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -85,7 +85,7 @@ var _ = Describe("restore/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -97,7 +97,7 @@ var _ = Describe("restore/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -111,7 +111,7 @@ var _ = Describe("restore/data tests", func() {
 			}
 			mock.ExpectExec(execStr).WillReturnError(pgErr)
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
-			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, false, 0, false)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("Error loading data into table public.foo: " +


### PR DESCRIPTION
Do not batch replicated tables

When restoring from a larger cluster to a smaller one, tables are [batched](https://github.com/arenadata/gpbackup/blob/76cd98a370dfadf39da8186c92b35f10deeb2a08/restore/data.go#L53-L59) from
several segments onto one. Such batching was [disabled](https://github.com/arenadata/gpbackup/blob/76cd98a370dfadf39da8186c92b35f10deeb2a08/helper/restore_helper.go#L204-L208) on the helper for
replicated tables, but not on the main process. As a result, the main process on
the coordinator launched several copy commands for replicated tables, which,
starting from the second, ended on segments with a missing pipe error. This
error was quietly ignored and could only be seen in the logs on the segments.

This patch disables batching for replicated tables on the coordinator.

---
Problem can be seen when testing "Can backup a 9-segment cluster and restore to current cluster with replicated tables", we can see in log on segments following lines
```csv
2024-05-14 18:56:40.485147 +05,"gpadmin","restoredb",p1249228,th-246704000,"172.19.0.3","60588",2024-05-14 18:56:40 +05,0,con22,cmd15,seg0,,dx41,,sx1,"LOG","00000","read err msg from pipe, len:120 msg:cat: /home/gpadmin/.data/6/dbfast1/demoDataDir0/gpbackup_0_20221104025347_pipe_1249204_16388: No such file or directory
",,,,,,,0,,,,
2024-05-14 18:56:40.488220 +05,"gpadmin","restoredb",p1249228,th-246704000,"172.19.0.3","60588",2024-05-14 18:56:40 +05,0,con22,cmd16,seg0,,dx42,,sx1,"LOG","00000","read err msg from pipe, len:120 msg:cat: /home/gpadmin/.data/6/dbfast1/demoDataDir0/gpbackup_0_20221104025347_pipe_1249204_16388: No such file or directory
",,,,,,,0,,,,
```