### PR TITLE
Use separate error buffers for different processes in gprestore helper

### DIFF
--- a/helper/helper.go
+++ b/helper/helper.go
@@ -2,7 +2,6 @@ package helper
 
 import (
 	"bufio"
-	"bytes"
 	"flag"
 	"fmt"
 	"os"
@@ -25,7 +24,6 @@ import (
 
 var (
 	CleanupGroup  *sync.WaitGroup
-	errBuf        bytes.Buffer
 	version       string
 	wasTerminated bool
 	writeHandle   *os.File


### PR DESCRIPTION
Use separate error buffers for different processes in gprestore helper

Problem description:
gprestore helper reused one error buffer for stderr of multiple processes when 
it worked with a plugin. It resulted in the following problem: if the plugin was 
launched several times, the error could be detected only on the 2nd run, while 
the error happens (i.e. plugin outputs something to the stderr) on each plugin 
run. 

Fix:
Add a separate error buffer for each RestoreReader.

As now there is no need for global 'errBuf' variable, it was moved to
'doBackupAgent' as a local variable (keeping it global without obvious need is a
bad practice). For the backup helper case, it is ok to have only one buffer as
only one backup plugin instance is started for each backup helper.

Tests are not added because the problem has no stable reproduction scenario - it
depends on the timing of writing to the stderr.