### PR TITLE
Store type for statistic as fqdn.

### DIFF
--- a/backup/queries_statistics.go
+++ b/backup/queries_statistics.go
@@ -54,7 +54,7 @@ type AttributeStatistic struct {
 }
 
 func (as AttributeStatistic) FQType() string {
-	if as.TypeSchema == "pg_catalog" {
+	if as.TypeSchema == "pg_catalog" || as.TypeSchema == "" {
 		return as.Type
 	} else {
 		return fmt.Sprintf("%s.%s", as.TypeSchema, as.Type)

--- a/backup/statistics.go
+++ b/backup/statistics.go
@@ -163,10 +163,10 @@ func generateAttributeSlotsQuery7(attStat AttributeStatistic) string {
 			realValues(attStat.Numbers3),
 			realValues(attStat.Numbers4),
 			realValues(attStat.Numbers5),
-			AnyValues(attStat.Values1, attStat.Type),
-			AnyValues(attStat.Values2, attStat.Type),
-			AnyValues(attStat.Values3, attStat.Type),
-			AnyValues(attStat.Values4, attStat.Type),
+			AnyValues(attStat.Values1, attStat.FQType()),
+			AnyValues(attStat.Values2, attStat.FQType()),
+			AnyValues(attStat.Values3, attStat.FQType()),
+			AnyValues(attStat.Values4, attStat.FQType()),
 			// Hyperloglog data structure for STATISTIC_KIND_HLL and
 			// STATISTIC_KIND_FULLHLL is converted into a bytea and
 			// always stored in last slot
@@ -234,10 +234,10 @@ func generateAttributeSlotsQuery6(attStat AttributeStatistic) string {
 			realValues(attStat.Numbers3),
 			realValues(attStat.Numbers4),
 			realValues(attStat.Numbers5),
-			AnyValues(attStat.Values1, attStat.Type),
-			AnyValues(attStat.Values2, attStat.Type),
-			AnyValues(attStat.Values3, attStat.Type),
-			AnyValues(attStat.Values4, attStat.Type),
+			AnyValues(attStat.Values1, attStat.FQType()),
+			AnyValues(attStat.Values2, attStat.FQType()),
+			AnyValues(attStat.Values3, attStat.FQType()),
+			AnyValues(attStat.Values4, attStat.FQType()),
 			// Hyperloglog data structure for STATISTIC_KIND_HLL and
 			// STATISTIC_KIND_FULLHLL is converted into a bytea and
 			// always stored in last slot

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -2260,14 +2260,8 @@ LANGUAGE plpgsql NO SQL;`)
 												`)
 
 			defer func() {
-				testhelper.AssertQueryRuns(backupConn, `drop table cdm.contact_status;
-														drop cast (text as cdm.status);
-														drop type cdm.status cascade;
-														drop schema cdm cascade;`)
-				testhelper.AssertQueryRuns(restoreConn, `drop table cdm.contact_status;
-														drop cast (text as cdm.status);
-														drop type cdm.status cascade;
-														drop schema cdm cascade;`)
+				testhelper.AssertQueryRuns(backupConn, `drop schema cdm cascade;`)
+				testhelper.AssertQueryRuns(restoreConn, `drop schema cdm cascade;`)
 			}()
 
 			type StatData struct {

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -2264,6 +2264,10 @@ LANGUAGE plpgsql NO SQL;`)
 														drop cast (text as cdm.status);
 														drop type cdm.status cascade;
 														drop schema cdm cascade;`)
+				testhelper.AssertQueryRuns(restoreConn, `drop table cdm.contact_status;
+														drop cast (text as cdm.status);
+														drop type cdm.status cascade;
+														drop schema cdm cascade;`)
 			}()
 
 			type StatData struct {

--- a/integration/statistics_queries_test.go
+++ b/integration/statistics_queries_test.go
@@ -47,13 +47,13 @@ var _ = Describe("backup integration tests", func() {
 			 * the same schema and data.
 			 */
 			expectedStats5I := backup.AttributeStatistic{Oid: tableOid, Schema: "public", Table: "foo", AttName: "i",
-				Type: "int4", Relid: tableOid, Inherit: false, Width: 4, Distinct: -1, Kind1: 2, Kind2: 3, Operator1: 97,
+				Type: "int4", TypeSchema: "pg_catalog", Relid: tableOid, Inherit: false, Width: 4, Distinct: -1, Kind1: 2, Kind2: 3, Operator1: 97,
 				Operator2: 97, Numbers2: []string{"1"}, Values1: []string{"1", "2", "3", "4"}}
 			expectedStats5J := backup.AttributeStatistic{Oid: tableOid, Schema: "public", Table: "foo", AttName: "j",
-				Type: "text", Relid: tableOid, Inherit: false, Width: 2, Distinct: -1, Kind1: 2, Kind2: 3, Operator1: 664,
+				Type: "text", TypeSchema: "pg_catalog", Relid: tableOid, Inherit: false, Width: 2, Distinct: -1, Kind1: 2, Kind2: 3, Operator1: 664,
 				Operator2: 664, Numbers2: []string{"1"}, Values1: []string{"a", "b", "c", "d"}}
 			expectedStats5K := backup.AttributeStatistic{Oid: tableOid, Schema: "public", Table: "foo", AttName: "k",
-				Type: "bool", Relid: tableOid, Inherit: false, Width: 1, Distinct: -0.5, Kind1: 1, Kind2: 3, Operator1: 91,
+				Type: "bool", TypeSchema: "pg_catalog", Relid: tableOid, Inherit: false, Width: 1, Distinct: -0.5, Kind1: 1, Kind2: 3, Operator1: 91,
 				Operator2: 58, Numbers1: []string{"0.5", "0.5"}, Numbers2: []string{"0.5"}, Values1: []string{"f", "t"}}
 			if connectionPool.Version.AtLeast("7") {
 				expectedStats5J.Collation1 = 100


### PR DESCRIPTION
Store type for statistic as fqdn.

This patch adds storing type for exported statistics as FQDN. Previously if
different schema was used for custom type definition, statistics could not be
restored because type name was used with no explicit schema definition. This
patch adds proper namespace to the type when backup generating restore
statements.