### PR TITLE
ADBDEV-6367: Fix backup for empty DB with statistics

### DIFF
--- a/backup/queries_statistics.go
+++ b/backup/queries_statistics.go
@@ -62,6 +62,10 @@ func (as AttributeStatistic) FQType() string {
 }
 
 func GetAttributeStatistics(connectionPool *dbconn.DBConn, tables []Table, processRow func(attStat *AttributeStatistic)) {
+	if len(tables) == 0 {
+		return
+	}
+
 	inheritClause := ""
 	statSlotClause := ""
 	if connectionPool.Version.AtLeast("6") {
@@ -148,6 +152,10 @@ type TupleStatistic struct {
 }
 
 func GetTupleStatistics(connectionPool *dbconn.DBConn, tables []Table, processRow func(tupleStat *TupleStatistic)) {
+	if len(tables) == 0 {
+		return
+	}
+
 	tablenames := make([]string, 0)
 	for _, table := range tables {
 		tablenames = append(tablenames, table.FQN())

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -2122,15 +2122,9 @@ LANGUAGE plpgsql NO SQL;`)
 			It("backup empty db with statistics", func() {
 				testutils.SkipIfBefore6(backupConn)
 
-				err := exec.Command("createdb", "emptydb").Run()
-				if err != nil {
-					Fail(fmt.Sprintf("Could not create emptydb: %v", err))
-				}
+				mustRunCommand(exec.Command("createdb", "emptydb"))
 				DeferCleanup(func() {
-					err = exec.Command("dropdb", "emptydb").Run()
-					if err != nil {
-						fmt.Printf("Could not drop emptydb: %v\n", err)
-					}
+					mustRunCommand(exec.Command("dropdb", "emptydb"))
 				})
 
 				output := gpbackup(gpbackupPath, backupHelperPath,


### PR DESCRIPTION
Fix backup for empty DB with statistics

`GetAttributeStatistics` and `GetTupleStatistics` did not handle the edge case
of 0 tables, causing gpbackup to fail. This patch adds a check for number of
tables and fixes the issue.