### PR TITLE
ADBDEV-6407: Replace default image for gpbackup tests

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -1,4 +1,4 @@
-ARG GPDB_IMAGE=gpdb6_regress:latest
+ARG GPDB_IMAGE=gpdb6_u22:latest
 FROM hub.adsw.io/library/$GPDB_IMAGE
 
 COPY . /home/gpadmin/go/src/github.com/greenplum-db/gpbackup

--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -1,4 +1,9 @@
-ARG GPDB_IMAGE=gpdb6_u22:latest
-FROM hub.adsw.io/library/$GPDB_IMAGE
+# Supported base images:
+# centos: hub.adsw.io/library/gpdb6_regress:latest
+# rocky: hub.adsw.io/library/gpdb7_regress:latest
+# ubuntu: hub.adsw.io/library/gpdb6_u22:latest
+# default image is centos
+ARG GPDB_IMAGE=hub.adsw.io/library/gpdb6_regress:latest
+FROM $GPDB_IMAGE
 
 COPY . /home/gpadmin/go/src/github.com/greenplum-db/gpbackup

--- a/arenadata/README.md
+++ b/arenadata/README.md
@@ -8,6 +8,6 @@ docker run --rm -it --sysctl 'kernel.sem=500 1024000 200 4096' gpbackup:test bas
 
 7x:
 ```bash
-docker build -t gpbackup:test7x -f arenadata/Dockerfile --build-arg GPDB_IMAGE=gpdb7_regress:latest .
+docker build -t gpbackup:test7x -f arenadata/Dockerfile --build-arg GPDB_IMAGE=hub.adsw.io/library/gpdb7_regress:latest .
 docker run --rm -it --sysctl 'kernel.sem=500 1024000 200 4096' gpbackup:test7x bash -c "ssh-keygen -A && /usr/sbin/sshd && bash /home/gpadmin/go/src/github.com/greenplum-db/gpbackup/arenadata/run_gpbackup_tests.bash"
 ```


### PR DESCRIPTION
Replace default image for gpbackup tests

This patch replaces the default image for gpbackup tests with full path.