### PR TITLE
ADBDEV-6613: Fix gpbackup/gprestore hanging on fatal error in goroutine

### DIFF
--- a/backup/data.go
+++ b/backup/data.go
@@ -206,6 +206,7 @@ func BackupDataForAllTables(tables []Table) []map[uint32]int64 {
 		go func(whichConn int) {
 			defer func() {
 				if panicErr := recover(); panicErr != nil {
+					cancel()
 					panicChan <- fmt.Errorf("%v", panicErr)
 				}
 			}()
@@ -306,6 +307,7 @@ func BackupDataForAllTables(tables []Table) []map[uint32]int64 {
 	go func() {
 		defer func() {
 			if panicErr := recover(); panicErr != nil {
+				cancel()
 				panicChan <- fmt.Errorf("%v", panicErr)
 			}
 		}()

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -2669,6 +2669,23 @@ LANGUAGE plpgsql NO SQL;`)
 			assertArtifactsCleaned("20240730085053")
 			testhelper.AssertQueryRuns(restoreConn, "DROP TABLE a; DROP TABLE b; DROP TABLE c; DROP TABLE d;")
 		})
+		It("Will not hang and fatal error after helper error on resize-restore with jobs", func() {
+			command := exec.Command("tar", "-xzf", "resources/4-segment-db-single-backup-dir.tar.gz", "-C", backupDir)
+			mustRunCommand(command)
+			command = exec.Command("mv",
+				path.Join(backupDir, "4-segment-db-single-backup-dir/backups/20240730/20240730085053/gpbackup_0_20240730085053_16417.gz"),
+				path.Join(backupDir, "4-segment-db-single-backup-dir/backups/20240730/20240730085053/gpbackup_0_20240730085053_16417.gz.1"))
+			mustRunCommand(command)
+			gprestoreCmd := exec.Command(gprestorePath,
+				"--timestamp", "20240730085053",
+				"--redirect-db", "restoredb",
+				"--backup-dir", path.Join(backupDir, "4-segment-db-single-backup-dir"),
+				"--resize-cluster", "--on-error-continue", "--jobs", "3")
+			output, _ := gprestoreCmd.CombinedOutput()
+			Expect(string(output)).To(ContainSubstring(`[CRITICAL]:-Encountered errors with 1 helper agent(s)`))
+			assertArtifactsCleaned("20240730085053")
+			testhelper.AssertQueryRuns(restoreConn, "DROP TABLE a; DROP TABLE b; DROP TABLE c; DROP TABLE d;")
+		})
 	})
 	Describe("Restore indexes and constraints on exchanged partition tables", func() {
 		BeforeEach(func() {

--- a/restore/data.go
+++ b/restore/data.go
@@ -40,7 +40,7 @@ func CopyTableIn(queryContext context.Context, connectionPool *dbconn.DBConn, ta
 		//helper.go handles compression, so we don't want to set it here
 		customPipeThroughCommand = utils.DefaultPipeThroughProgram
 		errorFile := fmt.Sprintf("%s_error", globalFPInfo.GetSegmentPipePathForCopyCommand())
-		readFromDestinationCommand = fmt.Sprintf("(timeout 300 bash -c \"while [[ ! -p \"%s\" && ! -f \"%s\" ]]; do sleep 1; done\" || (echo \"Pipe not found %s\">&2; exit 1)) && %s", destinationToRead, errorFile, destinationToRead, readFromDestinationCommand)
+		readFromDestinationCommand = fmt.Sprintf("(timeout --foreground 300 bash -c \"while [[ ! -p \"%s\" && ! -f \"%s\" ]]; do sleep 1; done\" || (echo \"Pipe not found %s\">&2; exit 1)) && %s", destinationToRead, errorFile, destinationToRead, readFromDestinationCommand)
 	} else if MustGetFlagString(options.PLUGIN_CONFIG) != "" {
 		readFromDestinationCommand = fmt.Sprintf("%s restore_data %s", pluginConfig.ExecutablePath, pluginConfig.ConfigPath)
 	}

--- a/restore/data.go
+++ b/restore/data.go
@@ -269,6 +269,7 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Co
 		go func(whichConn int) {
 			defer func() {
 				if panicErr := recover(); panicErr != nil {
+					cancel()
 					panicChan <- fmt.Errorf("%v", panicErr)
 				}
 			}()

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -57,7 +57,7 @@ var _ = Describe("restore/data tests", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("will restore a table from a single data file", func() {
-			execStr := regexp.QuoteMeta(fmt.Sprintf("COPY public.foo(i,j) FROM PROGRAM '(timeout 300 bash -c \"while [[ ! -p \"<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456\" && ! -f \"<SEG_DATA_DIR>/gpbackup_<SEGID>_20170101010101_pipe_%d_error\" ]]; do sleep 1; done\" || (echo \"Pipe not found <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456\">&2; exit 1)) && cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456' WITH CSV DELIMITER ',' ON SEGMENT", os.Getpid()))
+			execStr := regexp.QuoteMeta(fmt.Sprintf("COPY public.foo(i,j) FROM PROGRAM '(timeout --foreground 300 bash -c \"while [[ ! -p \"<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456\" && ! -f \"<SEG_DATA_DIR>/gpbackup_<SEGID>_20170101010101_pipe_%d_error\" ]]; do sleep 1; done\" || (echo \"Pipe not found <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456\">&2; exit 1)) && cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456' WITH CSV DELIMITER ',' ON SEGMENT", os.Getpid()))
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456"
 			_, err := restore.CopyTableIn(context.Background(), connectionPool, "public.foo", "(i,j)", filename, true, 0)


### PR DESCRIPTION
1) Make copy command cancelable

If the command used in copy does not support handling of SIGINT signal, then
such copy command cannot be canceled. timeout command does not handle SIGINT
signal by default, so its use in gprestore makes copy command cannot be
canceled until timeout command completes. This patch adds foreground argument
to timeout command so that it can handle SIGINT signal, and thus copy command
can be canceled while timeout command is running.

2) Fix gpbackup/gprestore hanging on fatal error in goroutine

gpbackup/gprestore would hang when a fatal error occurred in goroutine. This
was because fatal error in one goroutine was suppressed, while parallel
goroutines continued running. This patch adds cancel the context when recover
fatal error in goroutine, which causes the other goroutines to stop.

The test is added only for restore, and is not provided for backup, since it is
difficult to do without modifying the code.

---
This patch shouldn't be squashed!