### PR TITLE
ADBDEV-6893: Fix pre-creating the required number of pipes in gprestore

### DIFF
--- a/helper/restore_helper.go
+++ b/helper/restore_helper.go
@@ -257,7 +257,7 @@ func doRestoreAgent() error {
 				}
 			}
 		}
-		if batchNum == 0 && i < len(oidList)-*copyQueue {
+		if i < len(oidList)-*copyQueue {
 			nextOid := oidList[i+*copyQueue]
 			nextBatchNum := 0
 

--- a/helper/restore_helper.go
+++ b/helper/restore_helper.go
@@ -310,12 +310,10 @@ func doRestoreAgent() error {
 						logWarn(fmt.Sprintf("Oid %d, Batch %d: Skip file discovered, skipping this relation.", tableOid, batchNum))
 						err = nil
 						skipOid = tableOid
-						/* Close up to *copyQueue files with this tableOid */
-						for idx := 0; idx < *copyQueue; idx++ {
-							batchToDelete := batchNum + idx
-							if batchToDelete < batches {
-								closeAndDeletePipe(tableOid, batchToDelete)
-							}
+						/* Close up to 1 file with this tableOid */
+						batchToDelete := batchNum + 1
+						if batchToDelete < batches {
+							closeAndDeletePipe(tableOid, batchToDelete)
 						}
 						goto LoopEnd
 					} else {

--- a/utils/agent_remote.go
+++ b/utils/agent_remote.go
@@ -47,10 +47,9 @@ func CreateSegmentPipeOnAllHostsForBackup(oid string, c *cluster.Cluster, fpInfo
 }
 
 func CreateSegmentPipeOnAllHostsForRestore(oid string, c *cluster.Cluster, fpInfo filepath.FilePathInfo, helperIdx ...int) {
-	oidWithBatch := strings.Split(oid, ",")
 	remoteOutput := c.GenerateAndExecuteCommand("Creating segment data pipes", cluster.ON_SEGMENTS, func(contentID int) string {
 		pipeName := fpInfo.GetSegmentPipeFilePath(contentID, helperIdx...)
-		pipeName = fmt.Sprintf("%s_%s_%s", pipeName, oidWithBatch[0], oidWithBatch[1])
+		pipeName = fmt.Sprintf("%s_%s_0", pipeName, oid)
 		gplog.Debug("Creating pipe %s", pipeName)
 		return fmt.Sprintf("mkfifo %s", pipeName)
 	})


### PR DESCRIPTION
Fix pre-creating the required number of pipes in gprestore

Commit 2142387 introduced a problem with pre-creating pipes. gprestore expected
a pipe to be pre-created for each job/copy-queue-size. But the existing logic
was pre-creating pipes for batches of tables instead of the tables themselves.
This patch solves the problem by pre-creating pipes only for the first batches.