### PR TITLE
ADBDEV-6893: Fix pre-creating the required number of pipes in gprestore

### DIFF
--- a/restore/data.go
+++ b/restore/data.go
@@ -243,7 +243,7 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Co
 			}
 
 			utils.WriteOidListToSegments(oidList, globalCluster, fpInfo, HelperIdx(whichConn)...)
-			initialPipes := CreateInitialSegmentPipes(oidList, globalCluster, connectionPool, fpInfo, HelperIdx(whichConn)...)
+			initialPipes := CreateInitialSegmentPipes(oidList, globalCluster, connectionPool.NumConns*batches, fpInfo, HelperIdx(whichConn)...)
 			if wasTerminated.Load() {
 				return 0
 			}
@@ -352,13 +352,13 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Co
 	return numErrors
 }
 
-func CreateInitialSegmentPipes(oidList []string, c *cluster.Cluster, connectionPool *dbconn.DBConn, fpInfo filepath.FilePathInfo, helperIdx ...int) int {
+func CreateInitialSegmentPipes(oidList []string, c *cluster.Cluster, numConns int, fpInfo filepath.FilePathInfo, helperIdx ...int) int {
 	// Create min(connections, tables) segment pipes on each host
 	var maxPipes int
 	if !backupConfig.SingleDataFile {
 		maxPipes = 1 // Create single initial pipe for the first oid in the restore oids list for non --single-data-file data file restore.
-	} else if connectionPool.NumConns < len(oidList) {
-		maxPipes = connectionPool.NumConns
+	} else if numConns < len(oidList) {
+		maxPipes = numConns
 	} else {
 		maxPipes = len(oidList)
 	}


### PR DESCRIPTION
Fix pre-creating the required number of pipes in gprestore

Commit 2142387 introduced a problem with pre-creating pipes. gprestore expected
a pipe to be pre-created for each job/copy-queue-size. But the existing logic
was pre-creating pipes for batches of tables instead of the tables themselves.
The main process starts several goroutines, for some of which it does not
pre-create pipes, which leads to a 300-second wait for the pipe to be created
and a subsequent error in restoring the corresponding table. This patch solves
the problem by pre-creating the required number of pipes. The required number
is equal to the multiplication of the number of connections (which is equal to
jobs or copy-queue-size) and the number of batches, because the main process
starts goroutines based on the number of connections.

The tests were not added because it would require waiting in the tests for more
than 300 seconds, which is not very nice.

---
See the reproductoin in the task.