### PR TITLE
Update gpbackup to support external Orca

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Required for Greenplum Database 6 or higher, several tests require the `dummy_se
 ```bash
 pushd $(find ~/workspace/gpdb -name dummy_seclabel)
     make install
-    gpconfig -c shared_preload_libraries -v dummy_seclabel
+    gpconfig -c shared_preload_libraries -v "$(psql -At -c "SELECT array_to_string(array_append(string_to_array(current_setting('shared_preload_libraries'), ','), 'dummy_seclabel'), ',')" postgres)"
     gpstop -ra
     gpconfig -s shared_preload_libraries | grep dummy_seclabel
 popd

--- a/arenadata/run_gpbackup_tests.bash
+++ b/arenadata/run_gpbackup_tests.bash
@@ -30,6 +30,6 @@ wget https://golang.org/dl/go1.20.5.linux-amd64.tar.gz -O - | tar -C /opt -xz;
 su - gpadmin -c "
 source /usr/local/greenplum-db-devel/greenplum_path.sh;
 source ~/gpdb_src/gpAux/gpdemo/gpdemo-env.sh;
-gpconfig -c shared_preload_libraries -v \"$(psql -At -c "SELECT array_to_string(array_append(string_to_array(current_setting('shared_preload_libraries'), ','), 'dummy_seclabel'), ',')" postgres)\";
+gpconfig -c shared_preload_libraries -v \"\$(psql -At -c \"SELECT array_to_string(array_append(string_to_array(current_setting('shared_preload_libraries'), ','), 'dummy_seclabel'), ',')\" postgres)\";
 gpstop -ar;
 PATH=$PATH:/opt/go/bin:~/go/bin GOPATH=~/go make depend build install integration end_to_end -C /home/gpadmin/go/src/github.com/greenplum-db/gpbackup"

--- a/arenadata/run_gpbackup_tests.bash
+++ b/arenadata/run_gpbackup_tests.bash
@@ -30,6 +30,6 @@ wget https://golang.org/dl/go1.20.5.linux-amd64.tar.gz -O - | tar -C /opt -xz;
 su - gpadmin -c "
 source /usr/local/greenplum-db-devel/greenplum_path.sh;
 source ~/gpdb_src/gpAux/gpdemo/gpdemo-env.sh;
-gpconfig -c shared_preload_libraries -v dummy_seclabel;
+gpconfig -c shared_preload_libraries -v \"$(psql -At -c "SELECT array_to_string(array_append(string_to_array(current_setting('shared_preload_libraries'), ','), 'dummy_seclabel'), ',')" postgres)\";
 gpstop -ar;
 PATH=$PATH:/opt/go/bin:~/go/bin GOPATH=~/go make depend build install integration end_to_end -C /home/gpadmin/go/src/github.com/greenplum-db/gpbackup"


### PR DESCRIPTION
Update gpbackup to support external Orca

Problem:
gpbackup tests require the 'dummy_seclabel' Greenplum contrib module. But, when
setting this module to 'shared_preload_libraries', previous value of 
'shared_preload_libraries' is cleared out. Therefore, in case of GPDB with
external Orca (when Orca is a shared library), Orca is disabled during testing.
As Orca is an essential part of GPDB, testing the gpbackup with disabled Orca is
not correct.

Fix:
In setting of 'shared_preload_libraries', read current value, and add or remove
only 'dummy_seclabel' substring.
Plus, README file is updated with a proper command sample for 'gpconfig'.

--------------------

Steps to reproduce:

```bash
docker build -t gpbackup:test7x -f arenadata/Dockerfile --build-arg GPDB_IMAGE="hub.adsw.io/library/gpdb7_u22:feature_ADBDEV-6552" .
docker run --rm -it --sysctl 'kernel.sem=500 1024000 200 4096' gpbackup:test7x bash
```

in the docker container:

```bash
ssh-keygen -A && /usr/sbin/sshd && bash /home/gpadmin/go/src/github.com/greenplum-db/gpbackup/arenadata/run_gpbackup_tests.bash
export PATH=$PATH:/usr/local/greenplum-db-devel/bin/
psql postgres -U gpadmin -h localhost -p 7000
```

in psql execute `show shared_preload_libraries;`.

Actual result before the patch (orca is missing):
```
postgres=# show shared_preload_libraries ;
 shared_preload_libraries 
--------------------------
 dummy_seclabel
(1 row)

```

Expected result: `orca` is presented in `shared_preload_libraries` and planning is done via Orca.