### PR TITLE
ADBDEV-7175: Cleanup in gprestore kills only own helpers

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -843,7 +843,7 @@ var _ = Describe("backup and restore end to end tests", func() {
 		})
 		It(`Ensures that concurrent restores from the same backup will not interfere with each other's helpers`, func() {
 			testhelper.AssertQueryRuns(backupConn,
-				"CREATE TABLE public.t (i int) DISTRIBUTED BY (i)")
+				"CREATE TABLE public.t AS SELECT i FROM generate_series(1, 10) i DISTRIBUTED BY (i)")
 			defer testhelper.AssertQueryRuns(backupConn, "DROP TABLE public.t")
 			output := gpbackup(gpbackupPath, backupHelperPath,
 				"--single-data-file", "--include-table", "public.t")
@@ -877,6 +877,7 @@ var _ = Describe("backup and restore end to end tests", func() {
 			for err := range errchan {
 				Expect(err).ToNot(HaveOccurred())
 			}
+			assertDataRestored(restoreConn, map[string]int{"public.t": 10})
 		})
 		It(`ensures gprestore on corrupt backup with --on-error-continue logs error tables`, func() {
 			if segmentCount != 3 {

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -2787,7 +2787,6 @@ LANGUAGE plpgsql NO SQL;`)
 			assertArtifactsCleaned("20240730085053")
 			testhelper.AssertQueryRuns(restoreConn, "DROP TABLE a; DROP TABLE b; DROP TABLE c; DROP TABLE d;")
 		})
-
 	})
 	Describe("Restore indexes and constraints on exchanged partition tables", func() {
 		BeforeEach(func() {

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -841,7 +841,7 @@ var _ = Describe("backup and restore end to end tests", func() {
 			}
 			Expect(err).NotTo(HaveOccurred())
 		})
-		It(`Can backup and concurrent restores of same backup with helpers`, func() {
+		It(`Ensures that concurrent restores from the same backup will not interfere with each other's helpers`, func() {
 			testhelper.AssertQueryRuns(backupConn,
 				"CREATE TABLE public.t (i int) DISTRIBUTED BY (i)")
 			defer testhelper.AssertQueryRuns(backupConn, "DROP TABLE public.t")


### PR DESCRIPTION
Cleanup in gprestore kills only own helpers

If several restores of the same backup are launched simultaneously, then the
very first restore that completes during cleanup kills not only its helpers,
but also all helpers working with the same backup, because the processes are
filtered only by same TOC-file. The patch solves the problem by adding a filter
by the name of the pipe, which already has the PID of the main process of the
restore. gpbackup is not affected by this problem, because it will always have
a unique TOC-file.