### PR TITLE
ADBDEV-8171: Turn off the orca optimizer in gprestore

### DIFF
--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -88,6 +88,7 @@ SET check_function_bodies = false;
 SET client_min_messages = error;
 SET standard_conforming_strings = on;
 SET default_with_oids = off;
+SET optimizer = off;
 `
 
 	setupQuery += "SET gp_ignore_error_table = on;\n"


### PR DESCRIPTION
When planning queries from gprestore, Orca trying to plan a query, but it almost
always fails due to the lack of support for planning queries which containing
system tables. At the same time, the start of Orca planning takes a considerable
amount of time. This is especially noticeable when restoring statistics.

This patch disables orca in gprestore sessions.